### PR TITLE
Removed need for elevated rights when running tests.

### DIFF
--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -26,7 +26,7 @@ Describe "PSSlack Module PS$PSVersion" {
 
         It 'Should load' {
             $Module = Get-Module $ModuleName
-            $Module.Name | Should be $ModuleName
+            $Module.Name | Should Be $ModuleName
             $Commands = $Module.ExportedCommands.Keys
             $Commands -contains 'Find-SlackMessage' | Should Be $True
             $Commands -contains 'Get-PSSlackConfig' | Should Be $True
@@ -40,9 +40,9 @@ Describe "PSSlack Module PS$PSVersion" {
             $Config = Import-Clixml "$ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
             $Props = $Config.PSObject.Properties.Name
             #Loop is faster but less clear in failed tests.
-            $Props -contains 'Uri' | Should be $True
-            $Props -contains 'Token' | Should be $True
-            $Props -contains 'ArchiveUri' | Should be $True
+            $Props -contains 'Uri' | Should Be $True
+            $Props -contains 'Token' | Should Be $True
+            $Props -contains 'ArchiveUri' | Should Be $True
             $Config.Uri | Should BeNullOrEmpty
             $Config.Token | Should BeNullOrEmpty
             $Config.ArchiveUri | Should BeNullOrEmpty
@@ -66,7 +66,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
 
             $Config.Uri | Should BeOfType System.Security.SecureString
             $Config.Token | Should BeOfType System.Security.SecureString
-            $Config.ArchiveUri | Should be 'TestArchive'
+            $Config.ArchiveUri | Should Be 'TestArchive'
         }
 
         It 'Should set a user-specified file' {
@@ -81,7 +81,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
 
             $Config.Uri | Should BeOfType System.Security.SecureString
             $Config.Token | Should BeOfType System.Security.SecureString
-            $Config.ArchiveUri | Should be 'TestArchivex'
+            $Config.ArchiveUri | Should Be 'TestArchivex'
         }
     }
 }
@@ -94,17 +94,17 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
         It 'Should read PSSlack.xml' {
             $Config = Get-PSSlackConfig -Source PSSlack.xml
 
-            $Config.Uri | Should be 'TestUri'
-            $Config.Token | Should be 'TestToken'
-            $Config.ArchiveUri | Should be 'TestArchive'
+            $Config.Uri | Should Be 'TestUri'
+            $Config.Token | Should Be 'TestToken'
+            $Config.ArchiveUri | Should Be 'TestArchive'
         }
 
         It 'Should read PSSlack variable' {
             $Config = Get-PSSlackConfig -Source PSSlack
 
-            $Config.Uri | Should be 'TestUri'
-            $Config.Token | Should be 'TestToken'
-            $Config.ArchiveUri | Should be 'TestArchivex' #From running alternate path test before...
+            $Config.Uri | Should Be 'TestUri'
+            $Config.Token | Should Be 'TestToken'
+            $Config.ArchiveUri | Should Be 'TestArchivex' #From running alternate path test before...
         }
 
         It 'Should read a user-specified file' {
@@ -119,9 +119,9 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
 
             $Config = Get-PSSlackConfig -Path $AlternativePath
 
-            $Config.Uri | Should be 'TestUri'
-            $Config.Token | Should be 'TestToken'
-            $Config.ArchiveUri | Should be 'TestArchivex'
+            $Config.Uri | Should Be 'TestUri'
+            $Config.Token | Should Be 'TestToken'
+            $Config.ArchiveUri | Should Be 'TestArchivex'
         }
     }
 }
@@ -158,7 +158,7 @@ Describe "Send-SlackMessage PS$PSVersion" {
 
         It 'Should not pass parameters if not specified' {
             $x = Send-SlackMessage -Token Token -Text 'Hi'
-            $x.arg.count | Should be 6
+            $x.arg.count | Should Be 6
             $x.arg -contains '-Body:' | Should Be $True
             $x.arg -contains '-Method:' | Should Be $True
             $x.arg -contains '-Token:' | Should Be $True

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -59,7 +59,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
             $Params = @{
                 Uri= $TestUri
                 Token = $TestToken
-                ArchiveUri = "$TestArchive"
+                ArchiveUri = $TestArchive
             }
             Set-PSSlackConfig @params
             $Config = Import-Clixml "$ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
@@ -79,8 +79,8 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
             Set-PSSlackConfig @params
             $Config = Import-Clixml $AlternativePath
 
-            $Config.Uri | Should BeOfType 'System.Security.SecureString'
-            $Config.Token | Should BeOfType 'System.Security.SecureString'
+            $Config.Uri | Should BeOfType System.Security.SecureString
+            $Config.Token | Should BeOfType System.Security.SecureString
             $Config.ArchiveUri | Should be 'TestArchivex'
         }
     }

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -17,7 +17,7 @@ Import-Module $ModulePath -Force
 $TestUri = 'TestUri'
 $TestToken = 'TestToken'
 $TestArchive = 'TestArchive'
-$AlternativePath = 'C:\ThisSlackXml.xml'
+$AlternativePath = 'TestDrive:\ThisSlackXml.xml'
 
 Describe "PSSlack Module PS$PSVersion" {
     Context 'Strict mode' {
@@ -169,4 +169,3 @@ Describe "Send-SlackMessage PS$PSVersion" {
 }
 
 Remove-Item $ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml -force -Confirm:$False
-Remove-Item $AlternativePath -Force -Confirm:$False


### PR DESCRIPTION
If run without elevated rights, tests were failing out of the box with UnauthorizedAccessException for C:\ThisSlackXml.xml. This removes the need for elevated rights (and C:\, which should help with Core compatibility).