### PR TITLE
Fixed initial comment option for Public\Send-SlackFile.ps1

### DIFF
--- a/PSSlack/Public/Send-SlackFile.ps1
+++ b/PSSlack/Public/Send-SlackFile.ps1
@@ -82,7 +82,7 @@
             'Channel'     {$body.channels = $Channel -join ", " }
             'FileName'    {$body.filename = $FileName}
             'Title'       {$body.Title = $Title}
-            'Comment'     {$body.comment = $Comment}
+            'Comment'     {$body.initial_comment = $Comment}
             'FileType'    {$body.filetype = $FileType}
             }
             Write-Verbose "Send-SlackApi -Body $($body | Format-List | Out-String)"
@@ -126,12 +126,11 @@
                             "$Title$LF")}
             'Comment'     {$bodyLines += 
                             ("--$boundary$LF" +
-                            "Content-Disposition: form-data; name=`"comment`"$LF" +
+                            "Content-Disposition: form-data; name=`"initial_comment`"$LF" +
                             "Content-Type: multipart/form-data$LF$LF" +
-                            "$Title$LF")}
+                            "$Comment$LF")}
             }
             $bodyLines += "--$boundary--$LF"
-            
             try {
                 $response = Invoke-RestMethod -Uri $uri -Method Post -ContentType "multipart/form-data; boundary=`"$boundary`"" -Body $bodyLines
             }


### PR DESCRIPTION
For Slack's `file.upload` method, the argument to leave the first comment on an uploaded file is `initial_comment`.  Depending on how `Send-SlackFile` was invoked, the initial comment could have simply been the title of the file.