### PR TITLE
Proxy support

### DIFF
--- a/PSSlack/PSSlack.psm1
+++ b/PSSlack/PSSlack.psm1
@@ -43,6 +43,7 @@ Foreach($import in @($Public + $Private))
                 Uri = $null
                 Token = $null
                 ArchiveUri = $null
+                Proxy = $null
             } | Export-Clixml -Path "$PSScriptRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -Force -ErrorAction Stop
         }
         Catch

--- a/PSSlack/Public/Get-PSSlackConfig.ps1
+++ b/PSSlack/Public/Get-PSSlackConfig.ps1
@@ -8,7 +8,7 @@
 
     .PARAMETER Source
         Get the config data from either...
-        
+
             PSSlack:     the live module variable used for command defaults
             PSSlack.xml: the serialized PSSlack.xml that loads when importing the module
 
@@ -16,7 +16,7 @@
 
     .PARAMETER Path
         If specified, read config from this XML file.
-        
+
         Defaults to PSSlack.xml in the module root
 
     .FUNCTIONALITY
@@ -32,7 +32,7 @@
         [parameter(ParameterSetName='source')]
         $Path = "$ModuleRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
     )
-    
+
     if($PSCmdlet.ParameterSetName -eq 'source' -and $Source -eq "PSSlack" -and -not $PSBoundParameters.ContainsKey('Path'))
     {
         $Script:PSSlack
@@ -49,9 +49,10 @@
             }
         }
         Import-Clixml -Path $Path |
-            Select -Property ArchiveUri,
-                         @{l='Uri';e={Decrypt $_.Uri}},
-                         @{l='Token';e={Decrypt $_.Token}}
+            Select-Object -Property ArchiveUri,
+                                    @{l='Uri';e={Decrypt $_.Uri}},
+                                    @{l='Token';e={Decrypt $_.Token}},
+                                    Proxy
     }
 
 }

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -19,6 +19,10 @@ function Send-SlackApi
         Hash table of arguments to send to the Slack API.
 
     .PARAMETER Token
+        Slack token to use
+
+    .PARAMETER Proxy
+        Proxy server to use
 
     .FUNCTIONALITY
         Slack
@@ -29,11 +33,11 @@ function Send-SlackApi
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [string]$Method,
-        
+
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [hashtable]$Body = @{ },
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [ValidateScript({
@@ -46,9 +50,17 @@ function Send-SlackApi
                 $true
             }
         })]
-        [string]$Token = $Script:PSSlack.Token
+        [string]$Token = $Script:PSSlack.Token,
+
+        [string]$Proxy = $Script:PSSlack.Proxy
     )
-    
+    $Params = @{
+        Uri = "https://slack.com/api/$Method"
+    }
+    if($Proxy)
+    {
+        $Params['Proxy'] = $Proxy
+    }
     $Body.token = $Token
-    Invoke-RestMethod -Uri "https://slack.com/api/$Method" -body $Body
+    Invoke-RestMethod @Params -body $Body
 }

--- a/PSSlack/Public/Send-SlackMessage.ps1
+++ b/PSSlack/Public/Send-SlackMessage.ps1
@@ -21,7 +21,12 @@ function Send-SlackMessage {
 
         Default value is the value set by Set-PSSlackConfig
 
-        If Token is set, this is ignored.
+        If Token is set, this is ignored
+
+    .PARAMETER Proxy
+        Proxy server to use
+
+        Default value is the value set by Set-PSSlackConfig
 
     .PARAMETER SlackMessage
         A SlackMessage created by New-SlackMessage
@@ -36,14 +41,14 @@ function Send-SlackMessage {
 
     .PARAMETER Username
         Set your bot's user name.
-        
+
         If using a Token, must be used in conjunction with as_user set to false, otherwise ignored
 
         See authorship details: https://api.slack.com/methods/chat.postMessage#authorship
 
     .PARAMETER IconUrl
         URL to an image to use as the icon for this message.
-        
+
         If using a Token, must be used in conjunction with as_user set to false, otherwise ignored.
 
         See authorship details: https://api.slack.com/methods/chat.postMessage#authorship
@@ -228,10 +233,14 @@ function Send-SlackMessage {
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]$Token = $Script:PSSlack.Token,
-        
+
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [string]$Uri = $Script:PSSlack.Uri,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$Proxy = $Script:PSSlack.Proxy,
 
         [PSTypeName('PSSlack.Message')]
         [parameter(ParameterSetName = 'SlackMessage',
@@ -289,6 +298,11 @@ function Send-SlackMessage {
     {
         Write-Debug "Send-SlackMessage Bound parameters: $($PSBoundParameters | Out-String)`nParameterSetName $($PSCmdlet.ParameterSetName)"
         $Messages = @()
+        $ProxyParam = @{}
+        if($Proxy)
+        {
+            $ProxyParam.Proxy = $Proxy
+        }
     }
     process
     {
@@ -298,7 +312,7 @@ function Send-SlackMessage {
 
             switch ($psboundparameters.keys)
             {
-                'channel'     {$body.channel = $channel }    
+                'channel'     {$body.channel = $channel }
                 'text'        {$body.text     = $text}
                 'username'    {$body.username = $username}
                 'asuser'      {$body.as_user = $AsUser}
@@ -332,7 +346,7 @@ function Send-SlackMessage {
                 }
 
                 Write-Verbose "Send-SlackApi -Body $($Message | Format-List | Out-String)"
-                $response = Send-SlackApi -Method chat.postMessage -Body $Message -Token $Token
+                $response = Send-SlackApi @ProxyParam -Method chat.postMessage -Body $Message -Token $Token
 
                 if ($response.ok)
                 {
@@ -342,10 +356,10 @@ function Send-SlackMessage {
 
                 $response
             }
-            Elseif($Uri -or $Script:PSSlack.Uri)
+            elseif($Uri -or $Script:PSSlack.Uri)
             {
                 $json = ConvertTo-Json -Depth 4 -Compress -InputObject $Message
-                Invoke-RestMethod -Method Post -Body $json -Uri $Uri
+                Invoke-RestMethod @ProxyParam -Method Post -Body $json -Uri $Uri
             }
             else
             {

--- a/PSSlack/Public/Set-PSSlackConfig.ps1
+++ b/PSSlack/Public/Set-PSSlackConfig.ps1
@@ -28,6 +28,9 @@
 
         Used to generate a link to a specific archive URI, where appropriate
 
+    .PARAMETER Proxy
+        Proxy to use with Invoke-RESTMethod
+
     .PARAMETER Path
         If specified, save config file to this file path.  Defaults to PSSlack.xml in the module root.
 
@@ -39,14 +42,16 @@
         [string]$Uri,
         [string]$Token,
         [string]$ArchiveUri,
+        [string]$Proxy,
         [string]$Path = "$ModuleRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
     )
 
     Switch ($PSBoundParameters.Keys)
     {
-        'Uri'{ $Script:PSSlack.Uri = $Uri }
-        'Token'{ $Script:PSSlack.Token = $Token }
-        'ArchiveUri'{ $Script:PSSlack.ArchiveUri = $ArchiveUri }
+        'Uri'        { $Script:PSSlack.Uri = $Uri }
+        'Token'      { $Script:PSSlack.Token = $Token }
+        'ArchiveUri' { $Script:PSSlack.ArchiveUri = $ArchiveUri }
+        'Proxy'      { $Script:PSSlack.Proxy = $Proxy }
     }
 
     Function Encrypt {
@@ -59,9 +64,10 @@
 
     #Write the global variable and the xml
     $Script:PSSlack |
-        Select -Property ArchiveUri,
-                         @{l='Uri';e={Encrypt $_.Uri}},
-                         @{l='Token';e={Encrypt $_.Token}} |
+        Select-Object -Property ArchiveUri,
+                                @{l='Uri';e={Encrypt $_.Uri}},
+                                @{l='Token';e={Encrypt $_.Token}},
+                                Proxy |
         Export-Clixml -Path $Path -force
 
 }

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -11,12 +11,13 @@ $ModulePath = Join-Path $ENV:BHProjectPath $ModuleName
         $Verbose.add("Verbose",$True)
     }
 
-
 Import-Module $ModulePath -Force
 
 $TestUri = 'TestUri'
 $TestToken = 'TestToken'
 $TestArchive = 'TestArchive'
+$TestProxy = 'TestProxy'
+
 $AlternativePath = 'TestDrive:\ThisSlackXml.xml'
 
 Describe "PSSlack Module PS$PSVersion" {
@@ -43,9 +44,12 @@ Describe "PSSlack Module PS$PSVersion" {
             $Props -contains 'Uri' | Should Be $True
             $Props -contains 'Token' | Should Be $True
             $Props -contains 'ArchiveUri' | Should Be $True
+            $Props -contains 'Proxy' | Should Be $True
+
             $Config.Uri | Should BeNullOrEmpty
             $Config.Token | Should BeNullOrEmpty
             $Config.ArchiveUri | Should BeNullOrEmpty
+            $Config.Proxy | Should BeNullOrEmpty
         }
     }
 }
@@ -60,6 +64,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
                 Uri= $TestUri
                 Token = $TestToken
                 ArchiveUri = $TestArchive
+                Proxy = $TestProxy
             }
             Set-PSSlackConfig @params
             $Config = Import-Clixml "$ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
@@ -67,6 +72,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
             $Config.Uri | Should BeOfType System.Security.SecureString
             $Config.Token | Should BeOfType System.Security.SecureString
             $Config.ArchiveUri | Should Be 'TestArchive'
+            $Config.Proxy | Should Be 'TestProxy'
         }
 
         It 'Should set a user-specified file' {
@@ -74,6 +80,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
                 Uri= $TestUri
                 Token = $TestToken
                 ArchiveUri = "$TestArchive`x"
+                Proxy = "$TestProxy`x"
                 Path = $AlternativePath
             }
             Set-PSSlackConfig @params
@@ -82,6 +89,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
             $Config.Uri | Should BeOfType System.Security.SecureString
             $Config.Token | Should BeOfType System.Security.SecureString
             $Config.ArchiveUri | Should Be 'TestArchivex'
+            $Config.Proxy | Should Be 'TestProxyx'
         }
     }
 }
@@ -97,6 +105,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Uri | Should Be 'TestUri'
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchive'
+            $Config.Proxy | Should Be 'TestProxy'
         }
 
         It 'Should read PSSlack variable' {
@@ -105,7 +114,8 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Uri | Should Be 'TestUri'
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchivex' #From running alternate path test before...
-        }
+            $Config.Proxy | Should Be 'TestProxy'
+    }
 
         It 'Should read a user-specified file' {
             # We've tested set... use it here.
@@ -113,6 +123,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
                 Uri= $TestUri
                 Token = $TestToken
                 ArchiveUri = "$TestArchive`x"
+                Proxy = "$TestProxy`x"
                 Path = $AlternativePath
             }
             Set-PSSlackConfig @params
@@ -122,6 +133,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Uri | Should Be 'TestUri'
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchivex'
+            $Config.Proxy | Should Be 'TestProxyx'
         }
     }
 }

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -114,7 +114,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Uri | Should Be 'TestUri'
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchivex' #From running alternate path test before...
-            $Config.Proxy | Should Be 'TestProxy'
+            $Config.Proxy | Should Be 'TestProxyx' #From running alternate path test before...
     }
 
         It 'Should read a user-specified file' {
@@ -139,7 +139,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
 }
 
 # Tests have passed, rely on set-psslackconfig...
-Set-PSSlackConfig -Uri $null -Token $null -ArchiveUri $null
+Set-PSSlackConfig -Uri $null -Token $null -ArchiveUri $null -Proxy $null
 
 
 Describe "Send-SlackMessage PS$PSVersion" {


### PR DESCRIPTION
This adds proxy support to `Send-SlackMessage` and `Send-SlackAPI`, with defaults pointing at a new PSSlackConfig `Proxy` property.  We can add to other functions later if needed - my assumption is that this would be a system wide thing, and thus configured in the PSSlackConfig.

Only provisions for the `-Proxy` parameter on `Invoke-RestMethod` and `Invoke-WebRequest` are in place.

Leaving this open for a day or two in case there are any concerns - cheers!