### PR TITLE
Relocated config file to $env:TEMP

### DIFF
--- a/PSSlack/PSSlack.psm1
+++ b/PSSlack/PSSlack.psm1
@@ -34,21 +34,21 @@ Foreach($import in @($Public + $Private))
 }
 
 #Create / Read config
-    if(-not (Test-Path -Path "$PSScriptRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -ErrorAction SilentlyContinue))
+    if(-not (Test-Path -Path "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -ErrorAction SilentlyContinue))
     {
         Try
         {
-            Write-Warning "Did not find config file $PSScriptRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml, attempting to create"
+            Write-Warning "Did not find config file $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml, attempting to create"
             [pscustomobject]@{
                 Uri = $null
                 Token = $null
                 ArchiveUri = $null
                 Proxy = $null
-            } | Export-Clixml -Path "$PSScriptRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -Force -ErrorAction Stop
+            } | Export-Clixml -Path "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -Force -ErrorAction Stop
         }
         Catch
         {
-            Write-Warning "Failed to create config file $PSScriptRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml: $_"
+            Write-Warning "Failed to create config file $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml: $_"
         }
     }
 

--- a/PSSlack/Public/Get-PSSlackConfig.ps1
+++ b/PSSlack/Public/Get-PSSlackConfig.ps1
@@ -17,7 +17,7 @@
     .PARAMETER Path
         If specified, read config from this XML file.
 
-        Defaults to PSSlack.xml in the module root
+        Defaults to PSSlack.xml in the user temp folder
 
     .FUNCTIONALITY
         Slack
@@ -30,7 +30,7 @@
 
         [parameter(ParameterSetName='path')]
         [parameter(ParameterSetName='source')]
-        $Path = "$ModuleRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+        $Path = "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
     )
 
     if($PSCmdlet.ParameterSetName -eq 'source' -and $Source -eq "PSSlack" -and -not $PSBoundParameters.ContainsKey('Path'))

--- a/PSSlack/Public/Set-PSSlackConfig.ps1
+++ b/PSSlack/Public/Set-PSSlackConfig.ps1
@@ -32,7 +32,7 @@
         Proxy to use with Invoke-RESTMethod
 
     .PARAMETER Path
-        If specified, save config file to this file path.  Defaults to PSSlack.xml in the module root.
+        If specified, save config file to this file path.  Defaults to PSSlack.xml in the user temp folder.
 
     .FUNCTIONALITY
         Slack
@@ -43,7 +43,7 @@
         [string]$Token,
         [string]$ArchiveUri,
         [string]$Proxy,
-        [string]$Path = "$ModuleRoot\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+        [string]$Path = "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
     )
 
     Switch ($PSBoundParameters.Keys)

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -38,7 +38,7 @@ Describe "PSSlack Module PS$PSVersion" {
         }
 
         It 'Should have empty values in PSSlack.xml' {
-            $Config = Import-Clixml "$ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+            $Config = Import-Clixml "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
             $Props = $Config.PSObject.Properties.Name
             #Loop is faster but less clear in failed tests.
             $Props -contains 'Uri' | Should Be $True
@@ -67,7 +67,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
                 Proxy = $TestProxy
             }
             Set-PSSlackConfig @params
-            $Config = Import-Clixml "$ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+            $Config = Import-Clixml "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
 
             $Config.Uri | Should BeOfType System.Security.SecureString
             $Config.Token | Should BeOfType System.Security.SecureString
@@ -180,4 +180,4 @@ Describe "Send-SlackMessage PS$PSVersion" {
     }
 }
 
-Remove-Item $ModulePath\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml -force -Confirm:$False
+Remove-Item $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml -force -Confirm:$False


### PR DESCRIPTION
I've went ahead and moved the config file to the $env:TEMP folder (from a windows explorer %temp% brings you there). This should simplify the permissions needed to install/use module without requiring elevated permissions. 
Thanks in advance!