### PR TITLE
Expanded select, sort, and where aliases to their full cmdlet names.

### DIFF
--- a/PSSlack/Private/Get-PropertyOrder.ps1
+++ b/PSSlack/Private/Get-PropertyOrder.ps1
@@ -48,7 +48,7 @@ Function Get-PropertyOrder {
         #Get properties that meet specified parameters
         $firstObject.psobject.properties |
             Where-Object { $memberType -contains $_.memberType } |
-            Select -ExpandProperty Name |
+            Select-Object -ExpandProperty Name |
             Where-Object{ -not $excludeProperty -or $excludeProperty -notcontains $_ }
     }
 } #Get-PropertyOrder

--- a/PSSlack/Public/Get-SlackChannel.ps1
+++ b/PSSlack/Public/Get-SlackChannel.ps1
@@ -65,7 +65,7 @@
             # torn between independent queries, or filtering channels.list
             # submit a PR if this isn't performant enough or doesn't make sense.
             $Channels = $RawChannels.channels |
-                Where {$Name -Contains $_.name}
+                Where-Object {$Name -Contains $_.name}
         }
         elseif ($Name -and$HasWildCard)
         {

--- a/PSSlack/Public/Get-SlackGroup.ps1
+++ b/PSSlack/Public/Get-SlackGroup.ps1
@@ -65,7 +65,7 @@
             # torn between independent queries, or filtering groups.list
             # submit a PR if this isn't performant enough or doesn't make sense.
             $Groups = $RawGroups.groups |
-                Where {$Name -Contains $_.name}
+                Where-Object {$Name -Contains $_.name}
         }
         elseif ($Name -and$HasWildCard)
         {

--- a/PSSlack/Public/Get-SlackGroupHistory.ps1
+++ b/PSSlack/Public/Get-SlackGroupHistory.ps1
@@ -126,15 +126,15 @@
                     if($PageDirection -eq 'Forward')
                     {
 
-                        $ts = $response.messages.ts | sort | Select -last 1
+                        $ts = $response.messages.ts | Sort-Object | Select-Object -last 1
                         $Params.body.oldest = $ts
                         Write-Debug "Paging Forward.`n$(
                             [pscustomobject]@{
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | sort | Select -last 1
-                                SortFirst = $response.messages.ts | sort | Select -first 1
+                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"
@@ -153,8 +153,8 @@
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | sort | Select -last 1
-                                SortFirst = $response.messages.ts | sort | Select -first 1
+                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"
@@ -187,7 +187,7 @@
                         #Order our messages appropriately according to page direction
                         if($Paging -and $PageDirection -eq 'Forward')
                         {
-                            Parse-SlackMessage -InputObject $Response | Sort TimeStamp
+                            Parse-SlackMessage -InputObject $Response | Sort-Object TimeStamp
                         }
                         else
                         {

--- a/PSSlack/Public/Get-SlackHistory.ps1
+++ b/PSSlack/Public/Get-SlackHistory.ps1
@@ -126,15 +126,15 @@
                     if($PageDirection -eq 'Forward')
                     {
 
-                        $ts = $response.messages.ts | sort | Select -last 1
+                        $ts = $response.messages.ts | Sort-Object | Select-Object -last 1
                         $Params.body.oldest = $ts
                         Write-Debug "Paging Forward.`n$(
                             [pscustomobject]@{
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | sort | Select -last 1
-                                SortFirst = $response.messages.ts | sort | Select -first 1
+                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"
@@ -153,8 +153,8 @@
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | sort | Select -last 1
-                                SortFirst = $response.messages.ts | sort | Select -first 1
+                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"
@@ -187,7 +187,7 @@
                         #Order our messages appropriately according to page direction
                         if($Paging -and $PageDirection -eq 'Forward')
                         {
-                            Parse-SlackMessage -InputObject $Response | Sort TimeStamp
+                            Parse-SlackMessage -InputObject $Response | Sort-Object TimeStamp
                         }
                         else
                         {

--- a/PSSlack/Public/Get-SlackUser.ps1
+++ b/PSSlack/Public/Get-SlackUser.ps1
@@ -76,7 +76,7 @@
             # torn between independent queries, or filtering users.list
             # submit a PR if this isn't performant enough or doesn't make sense.
             $Users = $RawUsers.members |
-                Where {$Name -Contains $_.name}
+                Where-Object {$Name -Contains $_.name}
         }
         elseif ($Name -and $HasWildCard)
         {

--- a/PSSlack/Public/New-SlackField.ps1
+++ b/PSSlack/Public/New-SlackField.ps1
@@ -99,7 +99,7 @@
 
             if($IncludeProperty)
             {
-                $Properties = $Properties | Where {$IncludeProperty -contains $_}
+                $Properties = $Properties | Where-Object {$IncludeProperty -contains $_}
             }
 
             foreach($Property in $Properties)


### PR DESCRIPTION
First step in giving PSSlack a clean PSScriptAnalysis run by clearing PSAvoidUsingCmdletAliases warnings.