### PR TITLE
Initial implementation of Get-SlackTeam (team.info)

### DIFF
--- a/PSSlack/PSSlack.Format.ps1xml
+++ b/PSSlack/PSSlack.Format.ps1xml
@@ -4,7 +4,7 @@
         <View>
             <Name>Default</Name>
             <ViewSelectedBy>
-                <TypeName>PSSlack.SearchResult</TypeName>
+                <TypeName>PSSlack.Channel</TypeName>
             </ViewSelectedBy>
             <TableControl>
                 <TableHeaders>
@@ -12,7 +12,10 @@
                         <Width>20</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
-                        <Width>20</Width>
+                        <Width>11</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>60</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
                         <Width>60</Width>
@@ -23,13 +26,16 @@
                         <Wrap />
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Username</PropertyName>
+                                <PropertyName>Name</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Channel</PropertyName>
+                                <PropertyName>MemberCount</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Text</PropertyName>
+                                <PropertyName>Topic</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Purpose</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>
@@ -74,7 +80,7 @@
         <View>
             <Name>Default</Name>
             <ViewSelectedBy>
-                <TypeName>PSSlack.Channel</TypeName>
+                <TypeName>PSSlack.SearchResult</TypeName>
             </ViewSelectedBy>
             <TableControl>
                 <TableHeaders>
@@ -82,10 +88,7 @@
                         <Width>20</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
-                        <Width>11</Width>
-                    </TableColumnHeader>
-                    <TableColumnHeader>
-                        <Width>60</Width>
+                        <Width>20</Width>
                     </TableColumnHeader>
                     <TableColumnHeader>
                         <Width>60</Width>
@@ -96,23 +99,20 @@
                         <Wrap />
                         <TableColumnItems>
                             <TableColumnItem>
-                                <PropertyName>Name</PropertyName>
+                                <PropertyName>Username</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>MemberCount</PropertyName>
+                                <PropertyName>Channel</PropertyName>
                             </TableColumnItem>
                             <TableColumnItem>
-                                <PropertyName>Topic</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Purpose</PropertyName>
+                                <PropertyName>Text</PropertyName>
                             </TableColumnItem>
                         </TableColumnItems>
                     </TableRowEntry>
                 </TableRowEntries>
             </TableControl>
         </View>
-<View>
+        <View>
             <Name>Default</Name>
             <ViewSelectedBy>
                 <TypeName>PSSlack.User</TypeName>

--- a/PSSlack/PSSlack.Format.ps1xml
+++ b/PSSlack/PSSlack.Format.ps1xml
@@ -115,6 +115,41 @@
         <View>
             <Name>Default</Name>
             <ViewSelectedBy>
+                <TypeName>PSSlack.Team</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <TableHeaders>
+                    <TableColumnHeader>
+                        <Width>30</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>21</Width>
+                    </TableColumnHeader>
+                    <TableColumnHeader>
+                        <Width>30</Width>
+                    </TableColumnHeader>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <Wrap />
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Domain</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>EmailDomain</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+        <View>
+            <Name>Default</Name>
+            <ViewSelectedBy>
                 <TypeName>PSSlack.User</TypeName>
             </ViewSelectedBy>
             <TableControl>

--- a/PSSlack/PSSlack.psd1
+++ b/PSSlack/PSSlack.psd1
@@ -58,7 +58,7 @@ PowerShellVersion = '3.0'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Find-SlackMessage','Get-PSSlackConfig','Get-SlackChannel','Get-SlackGroup','Get-SlackGroupHistory','Get-SlackHistory','Get-SlackUser','New-SlackField','New-SlackMessage','New-SlackMessageAttachment','Send-SlackApi','Send-SlackFile','Send-SlackMessage','Set-PSSlackConfig')
+FunctionsToExport = @('Find-SlackMessage','Get-PSSlackConfig','Get-SlackChannel','Get-SlackGroup','Get-SlackGroupHistory','Get-SlackHistory','Get-SlackTeam','Get-SlackUser','New-SlackField','New-SlackMessage','New-SlackMessageAttachment','Send-SlackApi','Send-SlackFile','Send-SlackMessage','Set-PSSlackConfig')
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'

--- a/PSSlack/Private/Parse-SlackTeam.ps1
+++ b/PSSlack/Private/Parse-SlackTeam.ps1
@@ -1,0 +1,27 @@
+﻿# Parse users
+Function Parse-SlackTeam {
+    [CmdletBinding()]
+    param( $InputObject )
+
+    foreach($Team in $InputObject)
+    {
+        [PSCustomObject] @{
+            PSTypeName = 'PSSlack.Team'
+            ID = $Team.id
+            Name = $Team.name
+            Domain = $Team.domain
+            EmailDomain = ($Team.email_domain -split ',')
+            Icon = [Ordered] @{
+                Image34 = $Team.icon.image_34
+                Image44 = $Team.icon.image_44
+                Image68 = $Team.icon.image_68                    
+                Image88 = $Team.icon.image_88
+                Image102 = $Team.icon.image_102
+                Image132 = $Team.icon.image_132
+                Image230 = $Team.icon.image_230
+                ImageDefault = $Team.icon.image_default
+            }
+            Raw = $Team
+        }
+    }
+}

--- a/PSSlack/Private/Parse-SlackTeam.ps1
+++ b/PSSlack/Private/Parse-SlackTeam.ps1
@@ -14,7 +14,7 @@ Function Parse-SlackTeam {
             Icon = [Ordered] @{
                 Image34 = $Team.icon.image_34
                 Image44 = $Team.icon.image_44
-                Image68 = $Team.icon.image_68                    
+                Image68 = $Team.icon.image_68
                 Image88 = $Team.icon.image_88
                 Image102 = $Team.icon.image_102
                 Image132 = $Team.icon.image_132

--- a/PSSlack/Public/Get-SlackTeam.ps1
+++ b/PSSlack/Public/Get-SlackTeam.ps1
@@ -17,7 +17,25 @@
     .EXAMPLE
         Get-SlackTeam
 
-    .FUNCTIONALITY
+        # Gets the default Slack team specified by Get-PSSlackConfig.
+
+    .EXAMPLE
+        Get-SlackTeam -Token $Token
+
+        # Gets the  Slack team specified by $Token.
+    .EXAMPLE
+        Get-SlackTeam -Raw
+
+        # Gets the default Slack team specified by Get-PSSlackConfig.
+        # Returns raw output.
+
+    .EXAMPLE
+        Get-SlackTeam -Raw -Token $Token
+
+        # Gets the  Slack team specified by $Token.
+        # Returns raw output.
+
+        .FUNCTIONALITY
         Slack
 
     .LINK

--- a/PSSlack/Public/Get-SlackTeam.ps1
+++ b/PSSlack/Public/Get-SlackTeam.ps1
@@ -44,7 +44,25 @@
         }
         else
         {
-            $RawTeam
+            $Team = $RawTeam.team
+
+            [PSCustomObject] @{
+                PSTypeName = 'PSSlack.Team'
+                ID = $Team.id
+                Name = $Team.name
+                Domain = $Team.domain
+                EmailDomain = ($Team.email_domain -split ',')
+                Icon = [Ordered] @{
+                    Image34 = $Team.icon.image_34
+                    Image44 = $Team.icon.image_44
+                    Image68 = $Team.icon.image_68                    
+                    Image88 = $Team.icon.image_88
+                    Image102 = $Team.icon.image_102
+                    Image132 = $Team.icon.image_132
+                    Image230 = $Team.icon.image_230
+                    ImageDefault = $Team.icon.image_default
+                }
+            }
         }
     }
 }

--- a/PSSlack/Public/Get-SlackTeam.ps1
+++ b/PSSlack/Public/Get-SlackTeam.ps1
@@ -62,25 +62,7 @@
         }
         else
         {
-            $Team = $RawTeam.team
-
-            [PSCustomObject] @{
-                PSTypeName = 'PSSlack.Team'
-                ID = $Team.id
-                Name = $Team.name
-                Domain = $Team.domain
-                EmailDomain = ($Team.email_domain -split ',')
-                Icon = [Ordered] @{
-                    Image34 = $Team.icon.image_34
-                    Image44 = $Team.icon.image_44
-                    Image68 = $Team.icon.image_68                    
-                    Image88 = $Team.icon.image_88
-                    Image102 = $Team.icon.image_102
-                    Image132 = $Team.icon.image_132
-                    Image230 = $Team.icon.image_230
-                    ImageDefault = $Team.icon.image_default
-                }
-            }
+            Parse-SlackTeam -InputObject $RawTeam.team        
         }
     }
 }

--- a/PSSlack/Public/Get-SlackTeam.ps1
+++ b/PSSlack/Public/Get-SlackTeam.ps1
@@ -1,0 +1,50 @@
+﻿function Get-SlackTeam {
+    <#
+    .SYNOPSIS
+        Get info about the current Slack team.
+
+    .DESCRIPTION
+        Get info about the current Slack team.
+
+    .PARAMETER Token
+        Token to use for the Slack API.
+
+        Default value is the value set by Set-PSSlackConfig.
+
+    .PARAMETER Raw
+        Return raw output.
+
+    .EXAMPLE
+        Get-SlackTeam
+
+    .FUNCTIONALITY
+        Slack
+
+    .LINK
+        https://api.slack.com/methods/team.info
+    #>
+
+    [CmdletBinding()]
+    param (
+        [string]$Token = $Script:PSSlack.Token,
+        [switch]$Raw
+    )
+    end
+    {
+        $params = @{
+            Token = $Token
+            Method = 'team.info'
+        }
+
+        $RawTeam = Send-SlackApi @params
+
+        if($Raw)
+        {
+            $RawTeam
+        }
+        else
+        {
+            $RawTeam
+        }
+    }
+}


### PR DESCRIPTION
Initial implementation of Get-SlackTeam ([team.info](https://api.slack.com/methods/team.info)), including Parse-SlackTeam and a Slack.Team format.