### PR TITLE
Update Get-SlackFileInfo - Add support for video files

### DIFF
--- a/PSSlack/Public/Get-SlackFileInfo.ps1
+++ b/PSSlack/Public/Get-SlackFileInfo.ps1
@@ -19,6 +19,7 @@
             spaces - Posts
             snippets - Snippets
             images - Image files
+            videos - Video files
             gdocs - Google docs
             zips - Zip files
             pdfs - PDF files
@@ -56,7 +57,7 @@
         [string]$Channel,
         [datetime]$Before,
         [datetime]$After,
-        [validateset('all','spaces','snippets','images','gdocs','zips','pdfs')]
+        [validateset('all','spaces','snippets','images','videos','gdocs','zips','pdfs')]
         [string[]]$Types,
         [string]$User,
         [switch]$Paging,


### PR DESCRIPTION
Video files is a type now in Slack files, added in Get command to allow pulling those file types.

I needed to clean up these files in SQLCommunity Slack team, updated the function on local version to find the video files. Just has to be "videos", plural and worked fine.