### PR TITLE
Add API Error handling and local rate-limiting

### DIFF
--- a/PSSlack/PSSlack.psm1
+++ b/PSSlack/PSSlack.psm1
@@ -70,6 +70,10 @@ if($PSSlack.MapUser){
   $_PSSlackUserMap = Get-SlackUserMap -Update
 }
 
+# Create a hashtable for use with the "leaky bucket" rate-limiting algorithm. (Some of Slack's API calls will fail if you request them too quickly.)
+# https://en.wikipedia.org/wiki/Leaky_bucket
+$Script:PSSlack.APIRateBuckets = @{}
+
 # Import some color defs.
 $_PSSlackColorMap = @{
     aliceblue = "#F0F8FF"

--- a/PSSlack/PSSlack.psm1
+++ b/PSSlack/PSSlack.psm1
@@ -72,7 +72,7 @@ if($PSSlack.MapUser){
 
 # Create a hashtable for use with the "leaky bucket" rate-limiting algorithm. (Some of Slack's API calls will fail if you request them too quickly.)
 # https://en.wikipedia.org/wiki/Leaky_bucket
-$Script:PSSlack.APIRateBuckets = @{}
+$Script:APIRateBuckets = @{}
 
 # Import some color defs.
 $_PSSlackColorMap = @{

--- a/PSSlack/Private/Parse-SlackError.ps1
+++ b/PSSlack/Private/Parse-SlackError.ps1
@@ -1,0 +1,92 @@
+function Parse-SlackError {
+    [CmdletBinding()]
+    param (
+        # The response object from Slack's API.
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true
+        )]
+        [Object]$ResponseObject,
+
+        # The exception from Invoke-RestMethod, if available.
+        [Exception]$Exception
+    )
+
+    $SlackErrorData = @{
+        # Messages are adapted from Slack API documentation
+        invalid_arg_name = @{
+            Message = "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _." 
+            RecommendedAction = "Verify API call is well-formed."
+        }
+
+        invalid_array_arg = @{
+            Message = "The method was passed a PHP-style array argument (e.g. with a name like foo[7]). These are never valid with the Slack API."
+            RecommendedAction = "Rename or remove the argument"
+        }
+
+        invalid_charset = @{
+            Message = "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1."
+        }
+
+        invalid_form_data = @{
+            Message = "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid."
+        }
+
+        invalid_post_type = @{
+            Message = "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/x-www-form-urlencoded multipart/form-data text/plain."
+        }
+
+        missing_post_type = @{
+            Message = "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header."
+        }
+
+        team_added_to_org = @{
+            Message = "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete."
+            RecommendedAction = "Wait until migration is complete, then try the request again."
+        }
+
+        request_timeout = @{
+            Message = "The method was called via a POST request, but the POST data was either missing or truncated."
+        }
+
+        fatal_error = @{
+            Message = "The server could not complete your operation(s) without encountering a catastrophic error. Some aspect of the operation may have succeeded before the error was raised."
+        }
+
+        not_authed = @{
+            Message = "No authentication token provided."
+            RecommendedAction = "Specify an authentication token via the -Token or -URI parameters, then try again."
+        }
+
+        invalid_auth = @{
+            Message = "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request."
+        }
+
+        account_inactive = @{
+            Message = "Authentication token is for a deleted user or workspace."
+        }
+
+        no_permission = {
+            Message = "The workspace token used in this request does not have the permissions necessary to complete the request."
+
+        }
+    }
+    
+    process {
+        If ($ResponseObject.ok) {
+            # We weren't actually given an error in this case
+            Write-Debug "Parse-SlackError: Received non-error response, skipping."
+            return 
+        }
+
+        $ErrorParams = $ErrorParams[$ResponseObject.error]
+        If ($Exception) {
+            $ErrorParams.Exception = $Exception
+        }
+
+        Write-Error -ErrorId $ResponseObject.error @ErrorParams
+    }
+    
+    end {
+    }
+}

--- a/PSSlack/Private/Parse-SlackError.ps1
+++ b/PSSlack/Private/Parse-SlackError.ps1
@@ -12,63 +12,65 @@ function Parse-SlackError {
         [Exception]$Exception
     )
 
-    $SlackErrorData = @{
-        # Messages are adapted from Slack API documentation
-        invalid_arg_name = @{
-            Message = "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _." 
-            RecommendedAction = "Verify API call is well-formed."
-        }
+    Begin {
+        $SlackErrorData = @{
+            # Messages are adapted from Slack API documentation
+            invalid_arg_name = @{
+                Message = "The method was passed an argument whose name falls outside the bounds of accepted or expected values. This includes very long names and names with non-alphanumeric characters other than _." 
+                RecommendedAction = "Verify API call is well-formed."
+            }
 
-        invalid_array_arg = @{
-            Message = "The method was passed a PHP-style array argument (e.g. with a name like foo[7]). These are never valid with the Slack API."
-            RecommendedAction = "Rename or remove the argument"
-        }
+            invalid_array_arg = @{
+                Message = "The method was passed a PHP-style array argument (e.g. with a name like foo[7]). These are never valid with the Slack API."
+                RecommendedAction = "Rename or remove the argument"
+            }
 
-        invalid_charset = @{
-            Message = "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1."
-        }
+            invalid_charset = @{
+                Message = "The method was called via a POST request, but the charset specified in the Content-Type header was invalid. Valid charset names are: utf-8 iso-8859-1."
+            }
 
-        invalid_form_data = @{
-            Message = "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid."
-        }
+            invalid_form_data = @{
+                Message = "The method was called via a POST request with Content-Type application/x-www-form-urlencoded or multipart/form-data, but the form data was either missing or syntactically invalid."
+            }
 
-        invalid_post_type = @{
-            Message = "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/x-www-form-urlencoded multipart/form-data text/plain."
-        }
+            invalid_post_type = @{
+                Message = "The method was called via a POST request, but the specified Content-Type was invalid. Valid types are: application/x-www-form-urlencoded multipart/form-data text/plain."
+            }
 
-        missing_post_type = @{
-            Message = "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header."
-        }
+            missing_post_type = @{
+                Message = "The method was called via a POST request and included a data payload, but the request did not include a Content-Type header."
+            }
 
-        team_added_to_org = @{
-            Message = "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete."
-            RecommendedAction = "Wait until migration is complete, then try the request again."
-        }
+            team_added_to_org = @{
+                Message = "The workspace associated with your request is currently undergoing migration to an Enterprise Organization. Web API and other platform operations will be intermittently unavailable until the transition is complete."
+                RecommendedAction = "Wait until migration is complete, then try the request again."
+            }
 
-        request_timeout = @{
-            Message = "The method was called via a POST request, but the POST data was either missing or truncated."
-        }
+            request_timeout = @{
+                Message = "The method was called via a POST request, but the POST data was either missing or truncated."
+            }
 
-        fatal_error = @{
-            Message = "The server could not complete your operation(s) without encountering a catastrophic error. Some aspect of the operation may have succeeded before the error was raised."
-        }
+            fatal_error = @{
+                Message = "The server could not complete your operation(s) without encountering a catastrophic error. Some aspect of the operation may have succeeded before the error was raised."
+            }
 
-        not_authed = @{
-            Message = "No authentication token provided."
-            RecommendedAction = "Specify an authentication token via the -Token or -URI parameters, then try again."
-        }
+            not_authed = @{
+                Message = "No authentication token provided."
+                RecommendedAction = "Specify an authentication token via the -Token or -URI parameters, then try again."
+            }
 
-        invalid_auth = @{
-            Message = "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request."
-        }
+            invalid_auth = @{
+                Message = "Some aspect of authentication cannot be validated. Either the provided token is invalid or the request originates from an IP address disallowed from making the request."
+            }
 
-        account_inactive = @{
-            Message = "Authentication token is for a deleted user or workspace."
-        }
+            account_inactive = @{
+                Message = "Authentication token is for a deleted user or workspace."
+            }
 
-        no_permission = {
-            Message = "The workspace token used in this request does not have the permissions necessary to complete the request."
+            no_permission = {
+                Message = "The workspace token used in this request does not have the permissions necessary to complete the request."
 
+            }
         }
     }
     
@@ -79,7 +81,7 @@ function Parse-SlackError {
             return 
         }
 
-        $ErrorParams = $ErrorParams[$ResponseObject.error]
+        $ErrorParams = $SlackErrorData[$ResponseObject.error]
         If ($Exception) {
             $ErrorParams.Exception = $Exception
         }

--- a/PSSlack/Private/Parse-SlackError.ps1
+++ b/PSSlack/Private/Parse-SlackError.ps1
@@ -71,6 +71,11 @@ function Parse-SlackError {
                 Message = "The workspace token used in this request does not have the permissions necessary to complete the request."
 
             }
+
+            ratelimited = {
+                Message = "Slack API rate-limit exceeded."
+                RecommendedAction = "Try again in a few moments."
+            }
         }
     }
     
@@ -82,6 +87,12 @@ function Parse-SlackError {
         }
 
         $ErrorParams = $SlackErrorData[$ResponseObject.error]
+
+        If ($ErrorParams -eq $null) {
+            $ErrorParams = @{
+                Message = "Unknown error $($ResponseObject.error) received from Slack API."
+            }
+        }
         If ($Exception) {
             $ErrorParams.Exception = $Exception
         }

--- a/PSSlack/Public/Remove-SlackMessage.ps1
+++ b/PSSlack/Public/Remove-SlackMessage.ps1
@@ -154,7 +154,7 @@ function Remove-SlackMessage {
                         [ref]$ConfirmAll,
                         [ref]$RejectAll
                 )) {
-                    Send-SlackApi @Params
+                    Send-SlackApi @Params -RateLimit
                 }    
             }
         }

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -102,7 +102,7 @@ function Send-SlackApi
                 
             # Determine when the next drip will occur.
             $NextDrip = $Bucket.LastDrip.AddMilliseconds($Bucket.LeakRateMsec)
-            Write-Warning "Rate-limit bucket full, waiting..."
+            Write-Verbose "Rate-limit bucket full, waiting..."
             
             # Sleep until then.
             Start-Sleep -Milliseconds ($NextDrip - [DateTime]::Now).TotalMilliseconds
@@ -138,7 +138,7 @@ function Send-SlackApi
             $Bucket.LastDrip = [DateTime]::Now.AddSeconds($RetryPeriod).AddMilliseconds($Bucket.LeakRateMsec * -1).AddMilliseconds(50)
 
             # Warn the user.
-            Write-Warning "Slack API rate-limit exceeded - blocking for $RetryPeriod second(s)."
+            Write-Verbose "Slack API rate-limit exceeded - blocking for $RetryPeriod second(s)."
             
             # (We don't actually have to sleep here, but rather recurse - the next call will handle sleeping.)
             Send-SlackApi @PSBoundParameters

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -61,8 +61,8 @@ function Send-SlackApi
 
     # Create a "leaky bucket" for a given API token, indicating a counter of requests "in" the bucket and drip rate (per-second) that requests exit the bucket.
     # This is used to follow along with Slack's API rate-limiting algorithm.
-    If ($Script:PSSlack.APIRateBuckets[$Token] -eq $Null) {
-        $Script:PSSlack.APIRateBuckets[$Token] = @{
+    If ($Script:APIRateBuckets[$Token] -eq $Null) {
+        $Script:APIRateBuckets[$Token] = @{
             Counter = 0
             MaxCount = 25
             LeakRateMsec = 1000
@@ -81,7 +81,7 @@ function Send-SlackApi
     $Body.token = $Token
 
     # Update the bucket for this API key to "drain" it as necessary - even if we're not using a RLed API call in this instance.
-    $Bucket = $Script:PSSlack.APIRateBuckets[$Token]
+    $Bucket = $Script:APIRateBuckets[$Token]
 
     # If we should "drip" (non-zero counter, at least 1 drip period has elapsed)
     If ($Bucket.Counter -gt 0 -and ([DateTime]::Now - $Bucket.LastDrip).TotalMilliseconds -gt $Bucket.LeakRateMsec) {

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -24,6 +24,9 @@ function Send-SlackApi
     .PARAMETER Proxy
         Proxy server to use
 
+    .PARAMETER RateLimit
+        Indicates the API method is rate-limit and should use automatic back-off/retry upon receipt of a HTTP 429 (Too Many Requests) response from the server.
+
     .FUNCTIONALITY
         Slack
     #>
@@ -51,8 +54,23 @@ function Send-SlackApi
         })]
         [string]$Token = $Script:PSSlack.Token,
 
-        [string]$Proxy = $Script:PSSlack.Proxy
+        [string]$Proxy = $Script:PSSlack.Proxy,
+
+        [Switch]$RateLimit
     )
+
+    # Create a "leaky bucket" for a given API token, indicating a counter of requests "in" the bucket and drip rate (per-second) that requests exit the bucket.
+    # This is used to follow along with Slack's API rate-limiting algorithm.
+    If ($Script:PSSlack.APIRateBuckets[$Token] -eq $Null) {
+        $Script:PSSlack.APIRateBuckets[$Token] = @{
+            Counter = 0
+            MaxCount = 25
+            LeakRateMsec = 1000
+            LastDrip = [DateTime]::Now
+        }
+    }
+
+
     $Params = @{
         Uri = "https://slack.com/api/$Method"
     }
@@ -61,5 +79,83 @@ function Send-SlackApi
         $Params['Proxy'] = $Proxy
     }
     $Body.token = $Token
-    Invoke-RestMethod @Params -body $Body
+
+    # Update the bucket for this API key to "drain" it as necessary - even if we're not using a RLed API call in this instance.
+    $Bucket = $Script:PSSlack.APIRateBuckets[$Token]
+
+    # If we should "drip" (non-zero counter, at least 1 drip period has elapsed)
+    If ($Bucket.Counter -gt 0 -and ([DateTime]::Now - $Bucket.LastDrip).TotalMilliseconds -gt $Bucket.LeakRateMsec) {
+        # Figure out how many drips should have occurred.
+        $NumDrips = [Math]::Floor(([DateTime]::Now - $Bucket.LastDrip).TotalMilliseconds / $Bucket.LeakRateMsec)
+
+        # Decrement the counter by the number of drips (if the counter is nonzero afterwards), or set the counter to zero.
+        $Bucket.Counter -= [Math]::Min($NumDrips, $Bucket.Counter)
+
+        # Update the last drip timestamp to indicate we just dripped.
+        $Bucket.LastDrip = [DateTime]::Now
+    }
+
+    try {
+
+        # If we want to invoke a rate-limited API method and the bucket is full...
+        If ($RateLimit -and ($Bucket.Counter -eq $Bucket.MaxCount)) {
+                
+            # Determine when the next drip will occur.
+            $NextDrip = $Bucket.LastDrip.AddMilliseconds($Bucket.LeakRateMsec)
+            Write-Warning "Rate-limit bucket full, waiting..."
+            
+            # Sleep until then.
+            Start-Sleep -Milliseconds ($NextDrip - [DateTime]::Now).TotalMilliseconds
+            
+            # Drip accordingly.
+            $Bucket.Counter--
+            $Bucket.LastDrip = [DateTime]::Now
+
+        }
+
+        $Response = Invoke-RestMethod @Params -body $Body
+
+        # If we've successfully invoked a rate-limited API method...
+        If ($RateLimit -and $Response.ok) {
+
+            # Increase the counter for our bucket.
+            $Bucket.Counter++    
+        }
+
+    }
+    catch [System.Net.WebException] {
+        # If we're configured to do rate-limiting...
+        # (HTTP 429 is "Too Many Requests")
+        If ($_.Exception.Response.StatusCode -eq 429 -and $RateLimit) {
+
+            # Get the time before we can try again.
+            $RetryPeriod = $_.Exception.Response.Headers["Retry-After"]
+
+            # Set our bucket to be full.
+            $Bucket.Counter = $Bucket.MaxCount
+            
+            # Figure out when the last drip "should" have occurred, based on how many seconds we have until the next drip.
+            $Bucket.LastDrip = [DateTime]::Now.AddSeconds($RetryPeriod).AddMilliseconds($Bucket.LeakRateMsec * -1)
+
+            # Warn the user.
+            Write-Warning "Slack API rate-limit exceeded - blocking for $RetryPeriod second(s)."
+            
+            # (We don't actually have to sleep here, but rather recurse - the next call will handle sleeping.)
+            Send-SlackApi @PSBoundParameters
+            
+        } Else {
+
+            # Convert the error-message to an object. (Invoke-RestMethod will not return data by-default if a 4xx/5xx status code is generated.)
+            $_.ErrorDetails.Message | ConvertFrom-Json | Parse-SlackError -Exception $_.Exception -ErrorAction Stop
+            
+        }
+    }
+
+    # Check to see if we have confirmation that our API call failed.
+    # (Responses with exception-generating status codes are handled in the "catch" block above - this one is for errors that don't generate exceptions)
+    If ($Response -ne $null -and $Response.ok -eq $False) {
+        $Response | Parse-SlackError
+    }
+
+    
 }

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -135,7 +135,7 @@ function Send-SlackApi
             $Bucket.Counter = $Bucket.MaxCount
             
             # Figure out when the last drip "should" have occurred, based on how many seconds we have until the next drip.
-            $Bucket.LastDrip = [DateTime]::Now.AddSeconds($RetryPeriod).AddMilliseconds($Bucket.LeakRateMsec * -1)
+            $Bucket.LastDrip = [DateTime]::Now.AddSeconds($RetryPeriod).AddMilliseconds($Bucket.LeakRateMsec * -1).AddMilliseconds(50)
 
             # Warn the user.
             Write-Warning "Slack API rate-limit exceeded - blocking for $RetryPeriod second(s)."

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -25,7 +25,7 @@ function Send-SlackApi
         Proxy server to use
 
     .PARAMETER RateLimit
-        Indicates the API method is rate-limit and should use automatic back-off/retry upon receipt of a HTTP 429 (Too Many Requests) response from the server.
+        Indicates the API method is rate-limited and should automatically back-off/retry upon receipt of a HTTP 429 (Too Many Requests) response from the server.
 
     .FUNCTIONALITY
         Slack

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -155,6 +155,8 @@ function Send-SlackApi
     # (Responses with exception-generating status codes are handled in the "catch" block above - this one is for errors that don't generate exceptions)
     If ($Response -ne $null -and $Response.ok -eq $False) {
         $Response | Parse-SlackError
+    } Else {
+        Write-Output $Response
     }
 
     


### PR DESCRIPTION
This PR covers two separate, yet two related issues:

- PSSlack does not gracefully handle errors from the Slack API (Some of these come with 4xx/5xx HTTP status codes, meaning Invoke-RestMethod throws an exception)
- PSSlack does not respect Slack's API rate-limiting (see #52)

By adding in a basic error-handler on the API - one that handles both 4xx/5xx errors from the API as well as results where `ok` is `$false` - we can handle rate-limiting a little better.

Local rate-limiting has been implemented behind a switch (`-RateLimit`) on `Send-SlackApi`. This uses the [Leaky Bucket algorithm](https://en.wikipedia.org/wiki/Leaky_bucket) to allow for 25 burst requests, with 1 second between requests otherwise. This seems to be very similar to Slack's rate-limit parameters, and will automatically recover from rate-limit errors returned by Slack's API.

This PR should resolve #52.