### PR TITLE
Implement API connection test via Test-SlackApi

### DIFF
--- a/PSSlack/Public/Test-SlackApi.ps1
+++ b/PSSlack/Public/Test-SlackApi.ps1
@@ -1,0 +1,68 @@
+<#
+.SYNOPSIS
+    Tests connectivity to the Slack API.
+.DESCRIPTION
+    This cmdlet calls the Slack API.test method to ensure PSSlack is able to connect to (and invoke) API methods.
+.EXAMPLE
+    # Test connectivity without a token
+    PS C:\> Test-SlackApi
+    
+    # Test connectivity using a specified token
+    PS C:\> Test-SlackApi -Token "xoxp-111-222-333-456789abcdef"
+.INPUTS
+    A Slack API token to use, if desired.
+.OUTPUTS
+    A Boolean value indicating whether the call passed/failed, or the response object from Slack's API.
+.PARAMETER Token
+    The API token to use when communicating with the Slack API.
+.PARAMETER Raw
+    Return the raw response object from the Slack API, versus parsing it and returning a boolean.
+.NOTES
+    Test-SlackApi will not, by default, use the preconfigured Slack API token (as the api.test method does not require authorization).
+.FUNCTIONALITY
+    Slack
+.LINK
+    https://api.slack.com/methods/api.test
+#>
+function Test-SlackApi {
+    [CmdletBinding()]
+    param (
+        [ValidateNotNullOrEmpty()]
+        [String]$Token,
+
+        [Switch]$Raw
+    )
+    
+    process {
+        Write-Verbose "Testing Slack API."
+        $RequestID = New-Guid # Generate a unique value for us to use when checking requests coming back from Slack's API
+        Write-Debug "Unique ID: $RequestID"
+
+        $Params = @{
+            Body = @{
+                PSSlackRequestID = $RequestID
+            }
+            Method = "api.test"
+        }
+        If ($Token) {
+            Write-Verbose "Adding token to request."
+            $Params.Token = $Token
+        }
+        Write-Verbose "Calling Slack API..."
+        $Response = Send-SlackApi @Params
+
+        If ($Raw) {
+            Return $Response
+        } Elseif ($Response.ok) {
+            Write-Verbose "Received response from Slack api.test call."
+            If ($Response.args.PSSlackRequestID -eq $RequestID) {
+                Write-Verbose "Unique ID matches."
+                Return $true
+            } else {
+                Write-Error "Slack API call succeeded, but responded with incorrect value."
+            }
+        } else {
+            Return $False
+        }
+    }
+}

--- a/PSSlack/Public/Test-SlackApi.ps1
+++ b/PSSlack/Public/Test-SlackApi.ps1
@@ -1,30 +1,30 @@
-<#
-.SYNOPSIS
-    Tests connectivity to the Slack API.
-.DESCRIPTION
-    This cmdlet calls the Slack API.test method to ensure PSSlack is able to connect to (and invoke) API methods.
-.EXAMPLE
-    # Test connectivity without a token
-    PS C:\> Test-SlackApi
-    
-    # Test connectivity using a specified token
-    PS C:\> Test-SlackApi -Token "xoxp-111-222-333-456789abcdef"
-.INPUTS
-    A Slack API token to use, if desired.
-.OUTPUTS
-    A Boolean value indicating whether the call passed/failed, or the response object from Slack's API.
-.PARAMETER Token
-    The API token to use when communicating with the Slack API.
-.PARAMETER Raw
-    Return the raw response object from the Slack API, versus parsing it and returning a boolean.
-.NOTES
-    Test-SlackApi will not, by default, use the preconfigured Slack API token (as the api.test method does not require authorization).
-.FUNCTIONALITY
-    Slack
-.LINK
-    https://api.slack.com/methods/api.test
-#>
 function Test-SlackApi {
+    <#
+    .SYNOPSIS
+        Tests connectivity to the Slack API.
+    .DESCRIPTION
+        This cmdlet calls the Slack API.test method to ensure PSSlack is able to connect to (and invoke) API methods.
+    .EXAMPLE
+        # Test connectivity without a token
+        PS C:\> Test-SlackApi
+        
+        # Test connectivity using a specified token
+        PS C:\> Test-SlackApi -Token "xoxp-111-222-333-456789abcdef"
+    .INPUTS
+        A Slack API token to use, if desired.
+    .OUTPUTS
+        A Boolean value indicating whether the call passed/failed, or the response object from Slack's API.
+    .PARAMETER Token
+        The API token to use when communicating with the Slack API.
+    .PARAMETER Raw
+        Return the raw response object from the Slack API, versus parsing it and returning a boolean.
+    .NOTES
+        Test-SlackApi will not, by default, use the preconfigured Slack API token (as the api.test method does not require authorization).
+    .FUNCTIONALITY
+        Slack
+    .LINK
+        https://api.slack.com/methods/api.test
+    #>
     [CmdletBinding()]
     param (
         [ValidateNotNullOrEmpty()]

--- a/PSSlack/Public/Test-SlackApi.ps1
+++ b/PSSlack/Public/Test-SlackApi.ps1
@@ -49,7 +49,7 @@ function Test-SlackApi {
             $Params.Token = $Token
         }
         Write-Verbose "Calling Slack API..."
-        $Response = Send-SlackApi @Params
+        $Response = Send-SlackApi @Params -ErrorAction Stop
 
         If ($Raw) {
             Return $Response

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -185,7 +185,7 @@ Describe "Test-SlackApi" {
         Set-StrictMode -Version latest
         It "Should receive API response" {
             $x = Test-SlackApi
-            $x.ok | Should Be $true
+            $x | Should Be $true
         }
         It "Should fail with invalid API keys" {
             {Test-SlackApi -Token "PSSlack_InvalidAPIToken"} | Should -Throw

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -180,4 +180,18 @@ Describe "Send-SlackMessage PS$PSVersion" {
     }
 }
 
+Describe "Test-SlackApi" {
+    Context "Strict Mode" {
+        Set-StrictMode -Version latest
+        It "Should receive API response" {
+            $x = Test-SlackApi
+            $x.ok | Should Be $true
+        }
+        It "Should fail with invalid API keys" {
+            {Test-SlackApi -Token "PSSlack_InvalidAPIToken"} | Should -Throw
+        }
+    }
+    
+}
+
 Remove-Item $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml -force -Confirm:$False


### PR DESCRIPTION
Resolves #1.

Once #53 is merged in, augmenting this to take advantage of the additional error output should be very straightforward.

I'm not sure if we want to write a Pester test for checking the API's availability from inside of AppVeyor (it would cause builds to fail if the Slack API is having issues), but it's at least a thought.