### PR TITLE
Augment Send-SlackAPI to handle API calls that failed below the API

### DIFF
--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -149,7 +149,7 @@ function Send-SlackApi
             $_.ErrorDetails.Message | ConvertFrom-Json | Parse-SlackError -Exception $_.Exception -ErrorAction Stop
             
         } Else {
-            Write-Error -Exception $_.Exception -Message "Slack API call failed:$_"
+            Write-Error -Exception $_.Exception -Message "Slack API call failed: $_"
         }
     }
 

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -143,11 +143,13 @@ function Send-SlackApi
             # (We don't actually have to sleep here, but rather recurse - the next call will handle sleeping.)
             Send-SlackApi @PSBoundParameters
             
-        } Else {
+        } Elseif ($_.ErrorDetails.Message -ne $null) {
 
             # Convert the error-message to an object. (Invoke-RestMethod will not return data by-default if a 4xx/5xx status code is generated.)
             $_.ErrorDetails.Message | ConvertFrom-Json | Parse-SlackError -Exception $_.Exception -ErrorAction Stop
             
+        } Else {
+            Write-Error -Exception $_.Exception -Message "Slack API call failed:$_"
         }
     }
 


### PR DESCRIPTION
Resolves #55.

This PR slightly augments the error-handling code in `Send-SlackAPI` to provide better error visibility if the API call failed due to a failure that occurred below the API call itself (socket failure, failed DNS lookup, connectivity issues, etc.)