### PR TITLE
Use different PSSlack.xml paths on Windows and Linux.

### DIFF
--- a/PSSlack/PSSlack.psm1
+++ b/PSSlack/PSSlack.psm1
@@ -15,9 +15,9 @@ if(-not $IsCoreCLR)
 }
 else
 {
-    Write-Warning ("You are using PSSlack in with .NET Core.  Several features will not work:",
-                   "Set-PSSlackConfig cannot serialize tokens or URIs",
-                   "[System.Drawing.Color]::SOmeColor shortcut is not available" -join "`n`t")
+   Write-Warning ("You are using PSSlack in with .NET Core.  Several features will not work:",
+                  "Set-PSSlackConfig cannot serialize tokens or URIs",
+                  "[System.Drawing.Color]::SOmeColor shortcut is not available" -join "`n`t")
 }
 
 #Dot source the files
@@ -34,22 +34,23 @@ Foreach($import in @($Public + $Private))
 }
 
 #Create / Read config
-    if(-not (Test-Path -Path "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -ErrorAction SilentlyContinue))
+    $script:_PSSlackXmlpath = Get-PSSlackConfigPath
+    if(-not (Test-Path -Path $script:_PSSlackXmlpath -ErrorAction SilentlyContinue))
     {
         Try
         {
-            Write-Warning "Did not find config file $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml, attempting to create"
+            Write-Warning "Did not find config file $($script:_PSSlackXmlpath), attempting to create"
             [pscustomobject]@{
                 Uri = $null
                 Token = $null
                 ArchiveUri = $null
                 Proxy = $null
                 MapUser = $null
-            } | Export-Clixml -Path "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml" -Force -ErrorAction Stop
+            } | Export-Clixml -Path $($script:_PSSlackXmlpath) -Force -ErrorAction Stop
         }
         Catch
         {
-            Write-Warning "Failed to create config file $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml: $_"
+            Write-Warning "Failed to create config file $($script:_PSSlackXmlpath): $_"
         }
     }
 

--- a/PSSlack/Private/Get-PSSlackConfigPath.ps1
+++ b/PSSlack/Private/Get-PSSlackConfigPath.ps1
@@ -1,0 +1,17 @@
+function Get-PSSlackConfigPath
+{
+    [CmdletBinding()]
+    param()
+
+    end
+    {
+        if (Test-IsWindows)
+        {
+            Join-Path -Path $env:TEMP -ChildPath "$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+        }
+        else
+        {
+            Join-Path -Path $env:HOME -ChildPath '.psslack' # Leading . and no file extension to be Unixy.
+        }
+    }
+}

--- a/PSSlack/Private/Test-IsWindows.ps1
+++ b/PSSlack/Private/Test-IsWindows.ps1
@@ -1,0 +1,11 @@
+function Test-IsWindows
+{
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    end
+    {
+        !(Test-Path -Path Variable:\IsWindows) -or $IsWindows
+    }
+}

--- a/PSSlack/Public/Get-PSSlackConfig.ps1
+++ b/PSSlack/Public/Get-PSSlackConfig.ps1
@@ -17,7 +17,7 @@
     .PARAMETER Path
         If specified, read config from this XML file.
 
-        Defaults to PSSlack.xml in the user temp folder
+        Defaults to PSSlack.xml in the user temp folder on Windows, or .psslack in the user's home directory on Linux/macOS.
 
     .FUNCTIONALITY
         Slack
@@ -30,7 +30,7 @@
 
         [parameter(ParameterSetName='path')]
         [parameter(ParameterSetName='source')]
-        $Path = "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+        $Path = $script:_PSSlackXmlpath
     )
 
     if($PSCmdlet.ParameterSetName -eq 'source' -and $Source -eq "PSSlack" -and -not $PSBoundParameters.ContainsKey('Path'))

--- a/PSSlack/Public/Set-PSSlackConfig.ps1
+++ b/PSSlack/Public/Set-PSSlackConfig.ps1
@@ -35,7 +35,7 @@
         Whether to generate a map of Slack user ID to name on module load, for use in Slack File commands
 
     .PARAMETER Path
-        If specified, save config file to this file path.  Defaults to PSSlack.xml in the user temp folder.
+        If specified, save config file to this file path.  Defaults to PSSlack.xml in the user temp folder on Windows, or .psslack in the user's home directory on Linux/macOS.
 
     .FUNCTIONALITY
         Slack
@@ -47,7 +47,7 @@
         [string]$ArchiveUri,
         [string]$Proxy,
         [bool]$MapUser,
-        [string]$Path = "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
+        [string]$Path = $script:_PSSlackXmlpath
     )
 
     Switch ($PSBoundParameters.Keys)


### PR DESCRIPTION
Adds logic to store and read PSSlack config file from different locations depending on if using Windows or Linux/macOS.

For Linux, use $env:home/.psslack
For Windows, continue with existing naming scheme in $env:temp folder

Fixes #57

