### PR TITLE
Move rate limiting from leaky bucket to http header per #67

### DIFF
--- a/PSSlack/Public/Remove-SlackFile.ps1
+++ b/PSSlack/Public/Remove-SlackFile.ps1
@@ -18,7 +18,7 @@
         Remove-SlackFile -id F18UVDLR3 -Force
         # Remove a specific file without prompts
     .EXAMPLE
-        Get-SlackFileInfo -Before (Get-Date).AddYears(-1) | Remove-SlackFile -id F18UVDLR3
+        Get-SlackFileInfo -Before (Get-Date).AddYears(-1) | Remove-SlackFile
         # Remove files created over a year ago
     .FUNCTIONALITY
         Slack
@@ -56,6 +56,7 @@
                                                        "Removing [$FileID]",
                                                        [ref]$ConfirmAll,
                                                        [ref]$RejectAll)) {
+                    $Response = $null
                     $Response = Send-SlackApi @params
                     if($Raw)
                     {
@@ -76,7 +77,7 @@
                             ok = $false
                             Error = $Response.error
                             Raw = $Response
-                        }                        
+                        }
                     }
                 }
             }

--- a/PSSlack/Public/Remove-SlackMessage.ps1
+++ b/PSSlack/Public/Remove-SlackMessage.ps1
@@ -8,12 +8,12 @@ function Remove-SlackMessage {
         # Remove a message sent to a channel with ID C1W2X3Y4Z at Saturday, August 5, 2017 8:19:05 PM
         PS> Remove-SlackMessage -ChannelID "C1W2X3Y4Z" -TimeStamp 1501964345.000481
 
-        # Using a pipeline, Remove all messages sent to a channel by a specific bot/user 
+        # Using a pipeline, Remove all messages sent to a channel by a specific bot/user
         # (Multilined for clarity)
         PS> Get-SlackChannel -name "TargetChannel" |
-                Get-SlackHistory -Count 1000 | 
+                Get-SlackHistory -Count 1000 |
                 Where-Object Username -match "MalfunctioningBot" |
-                Remove-SlackMessage -ChannelID "C5H8XBUMV"       
+                Remove-SlackMessage -ChannelID "C5H8XBUMV"
     .INPUTS
         The message(s) to delete. These can be specified individually using their timestamps, or piped in from Get-SlackHistory or Find-SlackMessage.
     .OUTPUTS
@@ -27,8 +27,8 @@ function Remove-SlackMessage {
     .PARAMETER SearchResultObject
         A PSSlack.SearchResult object returned from Find-SlackMessage. This is intended for use in pipelined scenarios.
     .PARAMETER AsUser
-        Delete the message as the authed user associated with this request's token, using the "chat:write:user" scope. Bot users in this context are considered authed users. 
-        
+        Delete the message as the authed user associated with this request's token, using the "chat:write:user" scope. Bot users in this context are considered authed users.
+
         If not specified, the message will be deleted with the "chat:write:bot" scope.
     .PARAMETER Token
         The Slack API Token to use for authorizing this request.
@@ -100,15 +100,13 @@ function Remove-SlackMessage {
 
         [string]$Token = $Script:PSSlack.Token
     )
-    
+
     begin {
         Write-Verbose "$($PSBoundParameters | Out-String)"
         $RejectAll = $false
         $ConfirmAll = $false
-
-
     }
-    
+
     process {
 
         switch ($PSCmdlet.ParameterSetName) {
@@ -144,7 +142,7 @@ function Remove-SlackMessage {
                 $PSCmdlet.ShouldProcess(
                     "Removed the message [$($Body.ts)] from channel $($Body.channel)",
                     "Remove the message [$($Body.ts)] from channel $($Body.channel)?",
-                    "Removing messages" 
+                    "Removing messages"
             )) {
                 If (($Force -and -not $WhatIfPreference) -or
                     $PSCmdlet.ShouldContinue(
@@ -154,8 +152,8 @@ function Remove-SlackMessage {
                         [ref]$ConfirmAll,
                         [ref]$RejectAll
                 )) {
-                    Send-SlackApi @Params -RateLimit
-                }    
+                    Send-SlackApi @Params
+                }
             }
         }
     }

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -66,7 +66,7 @@ function Send-SlackApi
         $Response = $null
         $Response = Invoke-RestMethod @Params -Body $Body
     }
-    catch [System.Net.WebException], [Microsoft.PowerShell.Commands.HttpResponseException] {
+    catch {
         # (HTTP 429 is "Too Many Requests")
         if ($_.Exception.Response.StatusCode -eq 429) {
 
@@ -93,9 +93,6 @@ function Send-SlackApi
         else {
             Write-Error -Exception $_.Exception -Message "Slack API call failed: $_"
         }
-    }
-    catch {
-        Write-Error $_
     }
 
     # Check to see if we have confirmation that our API call failed.


### PR DESCRIPTION
This changes rate limit handling...

* Removes @hmmwhatsthisdo's leaky bucket implementation, which tried to avoid hitting a 429 in the first place, and handled when it hits
* Adds rate limit handling that relies on 429 responses and their `retry-after` header

I've tested this on core/macos so far

```
Name                           Value
----                           -----
PSVersion                      6.1.0-preview.2
PSEdition                      Core
GitCommitId                    v6.1.0-preview.2
OS                             Darwin 16.7.0 Darwin Kernel Version 16.7.0: Tue Jan 30 11:27:06 PS...
Platform                       Unix
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0...}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```

I suspect some of the oddities in my code come with .NET or PowerShell wonkiness, or the fact that I wrote this without caffeine : )

Opening a PR for comments, will wait on merging to see if there's any feedback, and to test on some other platforms