### PR TITLE
Update New-SlackMessageAttachment to fix pipeline

### DIFF
--- a/PSSlack/Public/New-SlackMessageAttachment.ps1
+++ b/PSSlack/Public/New-SlackMessageAttachment.ps1
@@ -307,7 +307,6 @@ function New-SlackMessageAttachment
 
         Add-ObjectDetail -InputObject $Attachment -TypeName 'PSSlack.MessageAttachment' -Passthru $False
         $ReturnObject = @()
-        $ptime = 0
     }
     Process
     {
@@ -316,7 +315,6 @@ function New-SlackMessageAttachment
             $ReturnObject += $a
         }
         
-        Write-Verbose $ptime
         If($ExistingAttachment)
         {
             Write-Verbose "Existing Attachemnt: $($ExistingAttachment | Convertto-Json -compress)"
@@ -324,7 +322,6 @@ function New-SlackMessageAttachment
     }
     End {
         $ReturnObject += $Attachment
-       # [array]::Reverse($ReturnObject)
         $ReturnObject
     }
 }

--- a/PSSlack/Public/New-SlackMessageAttachment.ps1
+++ b/PSSlack/Public/New-SlackMessageAttachment.ps1
@@ -223,6 +223,7 @@ function New-SlackMessageAttachment
     (
         [Parameter(ValueFromPipeline = $True)]
         [PSTypeName('PSSlack.MessageAttachment')]
+        [object[]]
         $ExistingAttachment,
 
         [Parameter(Mandatory=$true,
@@ -277,9 +278,7 @@ function New-SlackMessageAttachment
         {
             throw "The CallBackId parameter is required when the Actions parameter is used"
         }
-    }
-    Process
-    {
+        
         #consolidate the colour and severity parameters for the API.
         if($PSCmdlet.ParameterSetName -like 'Severity')
         {
@@ -307,14 +306,25 @@ function New-SlackMessageAttachment
         }
 
         Add-ObjectDetail -InputObject $Attachment -TypeName 'PSSlack.MessageAttachment' -Passthru $False
-
-        if($ExistingAttachment)
+        $ReturnObject = @()
+        $ptime = 0
+    }
+    Process
+    {
+        foreach($a in $ExistingAttachment)
         {
-            @($ExistingAttachment) + $Attachment
+            $ReturnObject += $a
         }
-        else
+        
+        Write-Verbose $ptime
+        If($ExistingAttachment)
         {
-            $Attachment
+            Write-Verbose "Existing Attachemnt: $($ExistingAttachment | Convertto-Json -compress)"
         }
+    }
+    End {
+        $ReturnObject += $Attachment
+       # [array]::Reverse($ReturnObject)
+        $ReturnObject
     }
 }

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -196,3 +196,25 @@ Describe "Test-SlackApi" {
 }
 
 Remove-Item $env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml -force -Confirm:$False
+
+Describe 'New-SlackMessageAttachment' {
+    It 'Should be a hashtable when not on pipeline' {
+        $message = New-SlackMessageAttachment -Text "Test" -Fallback "test"
+        $message | Should -BeOfType Hashtable
+    }
+
+    It 'Should Be an Array with Three Members, when Piped Three Times' {
+        $message = New-SlackMessageAttachment -text "test1" -Fallback 'Test1' |
+          New-SlackMessageAttachment -text "test2" -Fallback "test2" |
+          New-SlackMessageAttachment -text "test3" -FallBack "test3"
+        $message.Count | Should -BeExactly 3
+    }
+    It 'Should Be an Array with Five Members, when Piped Five Times' {
+        $message = New-SlackMessageAttachment -text "test1" -Fallback 'Test1' |
+          New-SlackMessageAttachment -text "test2" -Fallback "test2" |
+          New-SlackMessageAttachment -text "test3" -FallBack "test3" |
+          New-SlackMessageAttachment -text "test4" -Fallback "test4" |
+          New-SlackMessageAttachment -text "test5" -Fallback "test5" 
+        $message.Count | Should -BeExactly 5
+    }
+}


### PR DESCRIPTION
This fixes #73

What happens is that when you run via the
 pipeline, the PROCESS block is run for each
item in the `ExistingAttachements` variable.

Then it returns that item + the current one back to the pipeline.

When this happens, the next command in the pipeline starts to work on that new object.

This causes a cascade which is what causes the error you are seeing.

This fixes the issue by creating the new message attachment in the begin block (run once). Looping and adding each item to a new array, then returning the new object back via the end block (run once).