### PR TITLE
#85 Add configuration for ContentType

### DIFF
--- a/PSSlack/PSSlack.psm1
+++ b/PSSlack/PSSlack.psm1
@@ -38,6 +38,7 @@ Foreach($import in @($Public + $Private))
                 Proxy = $null
                 MapUser = $null
                 ForceVerbose = $False
+                ContentType = $null
             } | Export-Clixml -Path $($script:_PSSlackXmlpath) -Force -ErrorAction Stop
         }
         Catch

--- a/PSSlack/Public/Get-PSSlackConfig.ps1
+++ b/PSSlack/Public/Get-PSSlackConfig.ps1
@@ -54,7 +54,8 @@
                                     @{l='Token';e={Decrypt $_.Token}},
                                     Proxy,
                                     MapUser,
-                                    ForceVerbose
+                                    ForceVerbose,
+                                    ContentType
     }
 
 }

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -24,6 +24,9 @@ function Send-SlackApi
     .PARAMETER Proxy
         Proxy server to use
 
+    .PARAMETER ContentType
+        Message content type to use
+
     .PARAMETER ForceVerbose
         If specified, don't explicitly remove verbose output from Invoke-RestMethod
 
@@ -59,7 +62,9 @@ function Send-SlackApi
 
         [string]$Proxy = $Script:PSSlack.Proxy,
 
-        [switch]$ForceVerbose = $Script:PSSlack.ForceVerbose
+        [switch]$ForceVerbose = $Script:PSSlack.ForceVerbose,
+
+        [string]$ContentType = $Script:PSSlack.ContentType
     )
     $Params = @{
         Uri = "https://slack.com/api/$Method"
@@ -78,7 +83,7 @@ function Send-SlackApi
 
     try {
         $Response = $null
-        $Response = Invoke-RestMethod @Params -Body $Body
+        $Response = Invoke-RestMethod @Params -Body $Body -ContentType $ContentType
     }
     catch {
         # (HTTP 429 is "Too Many Requests")

--- a/PSSlack/Public/Send-SlackMessage.ps1
+++ b/PSSlack/Public/Send-SlackMessage.ps1
@@ -31,6 +31,11 @@ function Send-SlackMessage {
     .PARAMETER SlackMessage
         A SlackMessage created by New-SlackMessage
 
+    .PARAMETER ContentType
+        Set the content type of the message.
+
+        Default value is the value set by Set-PSSlackConfig.
+
     .PARAMETER Channel
         Channel, private group, or IM channel to send message to. Can be an encoded ID, or a name.
 
@@ -248,6 +253,10 @@ function Send-SlackMessage {
         [ValidateNotNullOrEmpty()]
         [string]$Proxy = $Script:PSSlack.Proxy,
 
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [string]$ContentType = $Script:PSSlack.ContentType,
+
         [PSTypeName('PSSlack.Message')]
         [parameter(ParameterSetName = 'SlackMessage',
                    ValueFromPipeline = $True)]
@@ -314,6 +323,10 @@ function Send-SlackMessage {
     }
     process
     {
+        if($ContentType -eq "")
+        {
+            $ContentType = "text/plain; charset=utf-8"
+        }
         if($PSCmdlet.ParameterSetName -eq 'Param')
         {
             $body = @{ }
@@ -354,7 +367,7 @@ function Send-SlackMessage {
                 }
 
                 Write-Verbose "Send-SlackApi -Body $($Message | Format-List | Out-String)"
-                $response = Send-SlackApi @ProxyParam -Method chat.postMessage -Body $Message -Token $Token -ForceVerbose:$ForceVerbose
+                $response = Send-SlackApi @ProxyParam -Method chat.postMessage -Body $Message -Token $Token -ContentType $ContentType -ForceVerbose:$ForceVerbose
 
                 if ($response.ok)
                 {
@@ -373,7 +386,7 @@ function Send-SlackMessage {
                     $ProxyParam.Add('Verbose', $true)
                 }
                 $json = ConvertTo-Json -Depth 6 -Compress -InputObject $Message
-                Invoke-RestMethod @ProxyParam -Method Post -Body $json -Uri $Uri
+                Invoke-RestMethod @ProxyParam -Method Post -Body $json -Uri $Uri -ContentType $ContentType
             }
             else
             {

--- a/PSSlack/Public/Set-PSSlackConfig.ps1
+++ b/PSSlack/Public/Set-PSSlackConfig.ps1
@@ -40,6 +40,9 @@
         *** WARNING ***
         If you set this to true, your Slack token will be visible as plain text in verbose output
 
+    .PARAMETER ContentType
+        Set the default content type for messages
+
     .PARAMETER Path
         If specified, save config file to this file path.  Defaults to PSSlack.xml in the user temp folder on Windows, or .psslack in the user's home directory on Linux/macOS.
 
@@ -54,6 +57,7 @@
         [string]$Proxy,
         [bool]$MapUser,
         [bool]$ForceVerbose,
+        [string]$ContentType,
         [string]$Path = $script:_PSSlackXmlpath
     )
 
@@ -65,6 +69,7 @@
         'Proxy'        { $Script:PSSlack.Proxy = $Proxy }
         'MapUser'      { $Script:PSSlack.MapUser = $MapUser }
         'ForceVerbose' { $Script:PSSlack.ForceVerbose = $ForceVerbose }
+        'ContentType'  { $Script:PSSlack.ContentType = $ContentType }
     }
 
     Function Encrypt {
@@ -82,7 +87,8 @@
                                 @{l='Token';e={Encrypt $_.Token}},
                                 Proxy,
                                 MapUser,
-                                ForceVerbose |
+                                ForceVerbose,
+                                ContentType |
         Export-Clixml -Path $Path -force
 
 }

--- a/Tests/PSSlack.Tests.ps1
+++ b/Tests/PSSlack.Tests.ps1
@@ -17,6 +17,7 @@ $TestUri = 'TestUri'
 $TestToken = 'TestToken'
 $TestArchive = 'TestArchive'
 $TestProxy = 'TestProxy'
+$TestContentType = 'TestContentType'
 
 $AlternativePath = 'TestDrive:\ThisSlackXml.xml'
 
@@ -45,11 +46,13 @@ Describe "PSSlack Module PS$PSVersion" {
             $Props -contains 'Token' | Should Be $True
             $Props -contains 'ArchiveUri' | Should Be $True
             $Props -contains 'Proxy' | Should Be $True
+            $Props -contains 'ContentType' | Should Be $True
 
             $Config.Uri | Should BeNullOrEmpty
             $Config.Token | Should BeNullOrEmpty
             $Config.ArchiveUri | Should BeNullOrEmpty
             $Config.Proxy | Should BeNullOrEmpty
+            $Config.ContentType | Should BeNullOrEmpty
         }
     }
 }
@@ -65,6 +68,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
                 Token = $TestToken
                 ArchiveUri = $TestArchive
                 Proxy = $TestProxy
+                ContentType = $TestContentType
             }
             Set-PSSlackConfig @params
             $Config = Import-Clixml "$env:TEMP\$env:USERNAME-$env:COMPUTERNAME-PSSlack.xml"
@@ -73,6 +77,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
             $Config.Token | Should BeOfType System.Security.SecureString
             $Config.ArchiveUri | Should Be 'TestArchive'
             $Config.Proxy | Should Be 'TestProxy'
+            $Config.ContentType | Should Be 'TestContentType'
         }
 
         It 'Should set a user-specified file' {
@@ -82,6 +87,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
                 ArchiveUri = "$TestArchive`x"
                 Proxy = "$TestProxy`x"
                 Path = $AlternativePath
+                ContentType = $TestContentType
             }
             Set-PSSlackConfig @params
             $Config = Import-Clixml $AlternativePath
@@ -90,6 +96,7 @@ Describe "Set-PSSlackConfig PS$PSVersion" {
             $Config.Token | Should BeOfType System.Security.SecureString
             $Config.ArchiveUri | Should Be 'TestArchivex'
             $Config.Proxy | Should Be 'TestProxyx'
+            $Config.ContentType | Should Be 'TestContentType'
         }
     }
 }
@@ -106,6 +113,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchive'
             $Config.Proxy | Should Be 'TestProxy'
+            $Config.ContentType | Should Be 'TestContentType'
         }
 
         It 'Should read PSSlack variable' {
@@ -115,6 +123,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchivex' #From running alternate path test before...
             $Config.Proxy | Should Be 'TestProxyx' #From running alternate path test before...
+            $Config.ContentType | Should Be 'TestContentType'
     }
 
         It 'Should read a user-specified file' {
@@ -125,6 +134,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
                 ArchiveUri = "$TestArchive`x"
                 Proxy = "$TestProxy`x"
                 Path = $AlternativePath
+                ContentType = $TestContentType
             }
             Set-PSSlackConfig @params
 
@@ -134,6 +144,7 @@ Describe "Get-PSSlackConfig PS$PSVersion" {
             $Config.Token | Should Be 'TestToken'
             $Config.ArchiveUri | Should Be 'TestArchivex'
             $Config.Proxy | Should Be 'TestProxyx'
+            $Config.ContentType | Should Be 'TestContentType'
         }
     }
 }
@@ -170,11 +181,13 @@ Describe "Send-SlackMessage PS$PSVersion" {
 
         It 'Should not pass parameters if not specified' {
             $x = Send-SlackMessage -Token Token -Text 'Hi'
-            # 6 we see here, 2 are from ForceVerbose resulting in Verbose $False...
-            $x.arg.count | Should Be 8
+            # 7 we see here, 1 for body value, 2 are from ForceVerbose resulting in Verbose $False...
+            $x.arg.count | Should Be 10 
             $x.arg -contains '-Body:' | Should Be $True
             $x.arg -contains '-Method:' | Should Be $True
             $x.arg -contains '-Token:' | Should Be $True
+            $x.arg -contains '-ContentType:' | Should Be $True
+            $x.arg -contains 'TestContentType' | Should Be $True
             $x.arg -contains 'Token' | Should Be $True
             $x.arg -contains 'chat.postMessage' | Should Be $True
         }


### PR DESCRIPTION
This change allows the user to configure the message content-type with an optional parameter or using the PSSlackConfig as requested in the linked issue.