### PR TITLE
Use fully qualified module path for Select-Object

### DIFF
--- a/PSSlack/Private/Get-PropertyOrder.ps1
+++ b/PSSlack/Private/Get-PropertyOrder.ps1
@@ -48,7 +48,7 @@ Function Get-PropertyOrder {
         #Get properties that meet specified parameters
         $firstObject.psobject.properties |
             Where-Object { $memberType -contains $_.memberType } |
-            Select-Object -ExpandProperty Name |
+            Microsoft.PowerShell.Utility\Select-Object -ExpandProperty Name |
             Where-Object{ -not $excludeProperty -or $excludeProperty -notcontains $_ }
     }
 } #Get-PropertyOrder

--- a/PSSlack/Private/Remove-SensitiveData.ps1
+++ b/PSSlack/Private/Remove-SensitiveData.ps1
@@ -19,7 +19,7 @@ function Remove-SensitiveData {
             $Output
         }
         else {
-            $InputObject | Select-Object -Property * -ExcludeProperty $SensitiveProperties
+            $InputObject | Microsoft.PowerShell.Utility\Select-Object -Property * -ExcludeProperty $SensitiveProperties
         }
     }
 }

--- a/PSSlack/Public/Get-PSSlackConfig.ps1
+++ b/PSSlack/Public/Get-PSSlackConfig.ps1
@@ -49,7 +49,7 @@
             }
         }
         Import-Clixml -Path $Path |
-            Select-Object -Property ArchiveUri,
+            Microsoft.PowerShell.Utility\Select-Object -Property ArchiveUri,
                                     @{l='Uri';e={Decrypt $_.Uri}},
                                     @{l='Token';e={Decrypt $_.Token}},
                                     Proxy,

--- a/PSSlack/Public/Get-SlackGroupHistory.ps1
+++ b/PSSlack/Public/Get-SlackGroupHistory.ps1
@@ -126,15 +126,18 @@
                     if($PageDirection -eq 'Forward')
                     {
 
-                        $ts = $response.messages.ts | Sort-Object | Select-Object -last 1
+                        $ts = $response.messages.ts | Sort-Object | 
+                            Microsoft.PowerShell.Utility\Select-Object -last 1
                         $Params.body.oldest = $ts
                         Write-Debug "Paging Forward.`n$(
                             [pscustomobject]@{
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
-                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
+                                SortLast = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"
@@ -153,8 +156,10 @@
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
-                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
+                                SortLast = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"

--- a/PSSlack/Public/Get-SlackHistory.ps1
+++ b/PSSlack/Public/Get-SlackHistory.ps1
@@ -119,15 +119,18 @@
                     if($PageDirection -eq 'Forward')
                     {
 
-                        $ts = $response.messages.ts | Sort-Object | Select-Object -last 1
+                        $ts = $response.messages.ts | Sort-Object | 
+                            Microsoft.PowerShell.Utility\Select-Object -last 1
                         $Params.body.oldest = $ts
                         Write-Debug "Paging Forward.`n$(
                             [pscustomobject]@{
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
-                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
+                                SortLast = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"
@@ -146,8 +149,10 @@
                                 After = $After
                                 Before = $Before
                                 LastTS = $response.messages[-1].ts
-                                SortLast = $response.messages.ts | Sort-Object | Select-Object -last 1
-                                SortFirst = $response.messages.ts | Sort-Object | Select-Object -first 1
+                                SortLast = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -last 1
+                                SortFirst = $response.messages.ts | Sort-Object | 
+                                    Microsoft.PowerShell.Utility\Select-Object -first 1
                                 ts = $ts
                             } | Out-String
                         )"

--- a/PSSlack/Public/Set-PSSlackConfig.ps1
+++ b/PSSlack/Public/Set-PSSlackConfig.ps1
@@ -77,7 +77,7 @@
 
     #Write the global variable and the xml
     $Script:PSSlack |
-        Select-Object -Property ArchiveUri,
+        Microsoft.PowerShell.Utility\Select-Object -Property ArchiveUri,
                                 @{l='Uri';e={Encrypt $_.Uri}},
                                 @{l='Token';e={Encrypt $_.Token}},
                                 Proxy,


### PR DESCRIPTION
Allows for PSSlack to be run in a constrained/Jea environment.

The only change here is replacing instances of Select-Object with Microsoft.PowerShell.Utility\Select-Object.

This allows PSSlack to be used in constrained endpoint /Jea environments as constrained endpoints load a limited version of Select-Object that breaks the module. Calling it using the fully qualified module path fixes the issue.