### PR TITLE
Fix #101

### DIFF
--- a/PSSlack/Public/Send-SlackMessage.ps1
+++ b/PSSlack/Public/Send-SlackMessage.ps1
@@ -373,7 +373,7 @@ function Send-SlackMessage {
                     $ProxyParam.Add('Verbose', $true)
                 }
                 $json = ConvertTo-Json -Depth 6 -Compress -InputObject $Message
-                Invoke-RestMethod @ProxyParam -Method Post -Body $json -Uri $Uri
+                Invoke-RestMethod @ProxyParam -Method Post -Body $json -Uri $Uri -ContentType "application/json; charset=utf-8"
             }
             else
             {


### PR DESCRIPTION
Implemented:

https://github.com/RamblingCookieMonster/PSSlack/issues/101#issuecomment-572182576
> 
> 
> https://github.com/RamblingCookieMonster/PSSlack/blob/b8ff0bd60aebfb270afd1973928ed8fcc137153a/PSSlack/Public/Send-SlackMessage.ps1#L376
> 
> Appending the option `-ContentType "application/json; charset=utf-8"` may fix this issue.
> 
> ```powershell
> Invoke-RestMethod -Method Post -Uri "https://hooks.slack.com/services/[snip]" -Body "{'text': 'Test message / テストメッセージ / Тестовое сообщение'}" -ContentType "application/json; charset=utf-8"
> ```
> 
> worked in PowerShell 6 in Ubuntu and 5 in Windows 10 (chcp 932).

