### PR TITLE
Fix TimeStamp and Channel IP parameters

### DIFF
--- a/PSSlack/Public/Remove-SlackMessage.ps1
+++ b/PSSlack/Public/Remove-SlackMessage.ps1
@@ -123,13 +123,15 @@ function Remove-SlackMessage {
             }
             switch ($PSCmdlet.ParameterSetName) {
                 "ByParameter" {
-                    $Body.ts = $MessageTS
+                    $Body.ts = $TimeStamp
                 }
                 "ByObject-History" {
                     $Body.ts = $Item.raw.ts
                 }
                 "ByObject-SearchResult" {
-                    $Body.channel = $Item.Channel
+                  if ([string]::IsNullOrWhiteSpace($Body.channel)){
+                  	  $Body.channel = $Item.Channel
+                  	}
                     $Body.ts = $Item.raw.ts
                 }
             }


### PR DESCRIPTION
1) TimeStamp wasn't getting set when called directly. Seemed to reference an old variable MessageTS?
2) The help example showed forcing / overriding a ChannelID when sending pipelined input. The code didn't seem to allow that previously, and specifying a ChannelID to be needed when deleting from a private channel, as the pipelined channel name isn't sufficient. Here's the example from the help file which now works for me after these edits:
         Get-SlackHistory -Count 1000 |
                Where-Object Username -match "MalfunctioningBot" |
                Remove-SlackMessage -ChannelID "C5H8XBUMV"