### PR TITLE
Fix API deprecation 2021-02-24

### DIFF
--- a/PSSlack/Public/Get-SlackChannel.ps1
+++ b/PSSlack/Public/Get-SlackChannel.ps1
@@ -108,7 +108,7 @@
 
         if($Name -and -not $HasWildCard)
         {
-            # torn between independent queries, or filtering channels.list
+            # torn between independent queries, or filtering conversations.list
             # submit a PR if this isn't performant enough or doesn't make sense.
             $Channels = $RawChannels.channels |
                 Where-Object {$Name -Contains $_.name}

--- a/PSSlack/Public/Get-SlackGroup.ps1
+++ b/PSSlack/Public/Get-SlackGroup.ps1
@@ -34,19 +34,21 @@
     end
     {
         Write-Verbose "$($PSBoundParameters | Remove-SensitiveData | Out-String)"
-
+        $body = @{
+            types = 'private_channel';
+        };
         if($ExcludeArchived)
         {
-            $body = @{ exclude_archived = 1 }
+            $body['exclude_archived'] = 1
         }
         else
         {
-            $body = @{ exclude_archived = 0 }
+            $body['exclude_archived'] = 0
         }
         $params = @{
             Body = $body
             Token = $Token
-            Method = 'groups.list'
+            Method = 'users.conversations'
         }
         $RawGroups = Send-SlackApi @params
 
@@ -62,14 +64,14 @@
 
         if($Name -and -not $HasWildCard)
         {
-            # torn between independent queries, or filtering groups.list
+            # torn between independent queries, or filtering users.conversations
             # submit a PR if this isn't performant enough or doesn't make sense.
-            $Groups = $RawGroups.groups |
+            $Groups = $RawGroups.channels |
                 Where-Object {$Name -Contains $_.name}
         }
         elseif ($Name -and$HasWildCard)
         {
-            $AllGroups = $RawGroups.groups
+            $AllGroups = $RawGroups.channels
 
             # allow like operator on each group requested in the param, avoid dupes
             $GroupHash = [ordered]@{}
@@ -87,7 +89,7 @@
         }
         else # nothing specified
         {
-            $Groups = $RawGroups.groups
+            $Groups = $RawGroups.channels
         }
 
         if($Raw)

--- a/PSSlack/Public/Get-SlackHistory.ps1
+++ b/PSSlack/Public/Get-SlackHistory.ps1
@@ -25,7 +25,7 @@
         If specified, include history from the date specified in Before and/or After parameters
 
     .PARAMETER Count
-        Number of messages to return per query.  Defaults to 100.  Max 1000
+        Maximum number of messages to return per query (see 'limit' on API docs).  Defaults to 100.  Max 1000
 
     .PARAMETER Paging
         If specified, and more data is available with a given 'Count', continue querying Slack until
@@ -64,7 +64,7 @@
         Write-Verbose "$($PSBoundParameters | Remove-SensitiveData | Out-String)"
         $body = @{
             channel = $null
-            count = $count
+            limit = $count
         }
         if($Paging)
         {
@@ -92,7 +92,7 @@
         }
         $params = @{
             Token = $Token
-            Method = 'channels.history'
+            Method = 'conversations.history'
             Body = $body
         }
         $Queries = 1

--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -64,6 +64,7 @@ function Send-SlackApi
     $Params = @{
         Uri = "https://slack.com/api/$Method"
         ErrorAction = 'Stop'
+        Header = @{ Authorization = "Bearer $Token" }
     }
     if($Proxy) {
         $Params['Proxy'] = $Proxy
@@ -74,7 +75,6 @@ function Send-SlackApi
     if($ForceVerbose) {
         $Params.Add('Verbose', $true)
     }
-    $Body.token = $Token
 
     try {
         $Response = $null


### PR DESCRIPTION
Solves breaking changes in https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps=0

- Change way of sending token #114 
- Use conversations instead of groups and channels #113 