### PR TITLE
Send a Message/File to a Thread

### DIFF
--- a/PSSlack/Public/New-SlackMessage.ps1
+++ b/PSSlack/Public/New-SlackMessage.ps1
@@ -25,7 +25,7 @@
 
     .PARAMETER IconUrl
         URL to an image to use as the icon for this message.
-        
+
         If using a token, must be used in conjunction with as_user set to false, otherwise ignored.
 
         See authorship details: https://api.slack.com/methods/chat.postMessage#authorship
@@ -45,6 +45,11 @@
 
     .PARAMETER LinkNames
         Find and link channel names and usernames.
+
+    .PARAMETER Thread
+        Optional thread where file is sent. Needs to be the parent thread id which is either the ts or thread_ts.
+
+        Can find a ts by querying https://api.slack.com/methods/conversations.history
 
     .PARAMETER Parse
         Change how messages are treated. Defaults to none
@@ -168,6 +173,7 @@
         [string]$IconEmoji,
         [switch]$AsUser,
         [switch]$LinkNames,
+        [string]$Thread,
 
         [validateset('full','none')]
         [string]$Parse,
@@ -208,6 +214,7 @@
             'iconurl'     { $body.icon_url     = $iconurl}
             'iconemoji'   { $body.icon_emoji   = $iconemoji}
             'linknames'   { $body.link_names   = 1}
+            'thread'      {$body.thread_ts = $Thread}
             'Parse'       { $body.Parse        = $Parse}
             'UnfurlLinks' { $body.Unfurl_Links = $UnfurlLinks}
             'UnfurlMedia' { $body.Unfurl_Media = $UnfurlMedia}

--- a/PSSlack/Public/Send-SlackFile.ps1
+++ b/PSSlack/Public/Send-SlackFile.ps1
@@ -144,6 +144,14 @@
                         $channelContent.Headers.ContentDisposition = $channelHeader
                         $multipartContent.Add($channelContent)
                     }
+                    'Thread' {
+                        # Add Thread
+                        $threadHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new('form-data')
+                        $threadHeader.Name = 'thread_ts'
+                        $threadContent = [System.Net.Http.StringContent]::new($Thread)
+                        $threadContent.Headers.ContentDisposition = $threadHeader
+                        $multipartContent.Add($threadContent)
+                    }
                     'FileName' {
                         # Add file name
                         $filenameHeader = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new('form-data')
@@ -208,10 +216,10 @@
                                 "Content-Type: multipart/form-data$LF$LF" +
                                 ($Channel -join ", ") + $LF)}
                 'Thread'     {$bodyLines +=
-                                    ("--$boundary$LF" +
-                                    "Content-Disposition: form-data; name=`"thread_ts`"$LF" +
-                                    "Content-Type: multipart/form-data$LF$LF" +
-                                    "$Thread$LF")}
+                                ("--$boundary$LF" +
+                                "Content-Disposition: form-data; name=`"thread_ts`"$LF" +
+                                "Content-Type: multipart/form-data$LF$LF" +
+                                "$Thread$LF")}
                 'FileName'    {$bodyLines +=
                                 ("--$boundary$LF" +
                                 "Content-Disposition: form-data; name=`"filename`"$LF" +

--- a/PSSlack/Public/Send-SlackFile.ps1
+++ b/PSSlack/Public/Send-SlackFile.ps1
@@ -22,6 +22,11 @@
     .PARAMETER Channel
         Optional channel, private group, or IM channel to send file to. Can be an encoded ID, or a name.
 
+    .PARAMETER Thread
+        Optional thread where file is sent. Needs to be the parent thread id which is either the ts or thread_ts.
+
+        Can find a ts by querying https://api.slack.com/methods/conversations.history
+
     .PARAMETER FileName
         Required filename for this file.  Used to determine syntax highlighting and other functionality.
 
@@ -75,6 +80,7 @@
         [string]$FileType,
 
         [string[]]$Channel,
+        [string]$Thread,
         [string]$FileName,
         [String]$Title,
         [String]$Comment,
@@ -88,6 +94,7 @@
             switch ($psboundparameters.keys) {
             'Content'     {$body.content     = $content}
             'Channel'     {$body.channels = $Channel -join ", " }
+            'Thread'      {$body.thread_ts = $Thread}
             'FileName'    {$body.filename = $FileName}
             'Title'       {$body.Title = $Title}
             'Comment'     {$body.initial_comment = $Comment}
@@ -200,6 +207,11 @@
                                 "Content-Disposition: form-data; name=`"channels`"$LF" +
                                 "Content-Type: multipart/form-data$LF$LF" +
                                 ($Channel -join ", ") + $LF)}
+                'Thread'     {$bodyLines +=
+                                    ("--$boundary$LF" +
+                                    "Content-Disposition: form-data; name=`"thread_ts`"$LF" +
+                                    "Content-Type: multipart/form-data$LF$LF" +
+                                    "$Thread$LF")}
                 'FileName'    {$bodyLines +=
                                 ("--$boundary$LF" +
                                 "Content-Disposition: form-data; name=`"filename`"$LF" +

--- a/PSSlack/Public/Send-SlackMessage.ps1
+++ b/PSSlack/Public/Send-SlackMessage.ps1
@@ -46,6 +46,11 @@ function Send-SlackMessage {
 
         See authorship details: https://api.slack.com/methods/chat.postMessage#authorship
 
+    .PARAMETER Thread
+        The id of the parent message you want to thread. This is usually seen as ts or thread_ts in a response.
+
+        Can find a ts by querying https://api.slack.com/methods/conversations.history
+
     .PARAMETER IconUrl
         URL to an image to use as the icon for this message.
 
@@ -265,6 +270,10 @@ function Send-SlackMessage {
         $Username,
 
         [parameter(ParameterSetName = 'Param',
+        ValueFromPipelineByPropertyName = $True)]
+        $Thread,
+
+        [parameter(ParameterSetName = 'Param',
                    ValueFromPipelineByPropertyName = $True)]
         $IconUrl,
 
@@ -322,6 +331,7 @@ function Send-SlackMessage {
             {
                 'channel'     {$body.channel = $channel }
                 'text'        {$body.text     = $text}
+                'thread'      {$body.thread_ts = $Thread}
                 'username'    {$body.username = $username}
                 'asuser'      {$body.as_user = $AsUser}
                 'iconurl'     {$body.icon_url = $iconurl}


### PR DESCRIPTION
 Includes the enhancement suggested in #100  A little bit different implementation than originally outlined, but very similar.

Examples:
```powershell
Send-SlackMessage -Text 'Doing Something' -Channel chatops -Thread '1623039865.004000'
Send-SlackFile -Content "Here You Go" -FileType Text -FileName File.txt -Channel chatops -Thread '1623039865.004000'
```
Example output:
![PSSlack](https://user-images.githubusercontent.com/13426972/120960066-9e2a1f00-c74a-11eb-9b84-6423ae439ac8.PNG)
