### PR TITLE
Authorization Header added for new slack apps

### DIFF
--- a/PSSlack/Public/Send-SlackAPI.ps1
+++ b/PSSlack/Public/Send-SlackAPI.ps1
@@ -64,6 +64,7 @@ function Send-SlackApi
     $Params = @{
         Uri = "https://slack.com/api/$Method"
         ErrorAction = 'Stop'
+        Headers = @{Authorization="Bearer "+$Token;}
     }
     if($Proxy) {
         $Params['Proxy'] = $Proxy
@@ -74,7 +75,6 @@ function Send-SlackApi
     if($ForceVerbose) {
         $Params.Add('Verbose', $true)
     }
-    $Body.token = $Token
 
     try {
         $Response = $null


### PR DESCRIPTION
Instead, apps must send tokens in the `Authorization` HTTP header or alternatively as a URL-encoded POST body parameter

https://api.slack.com/changelog/2020-11-no-more-tokens-in-querystrings-for-newly-created-apps