### PR TITLE
Removed duplicate `link` property when using $Raw

### DIFF
--- a/PSSlack/Public/Find-SlackMessage.ps1
+++ b/PSSlack/Public/Find-SlackMessage.ps1
@@ -107,8 +107,6 @@
 
                 if($Raw)
                 {
-                    $link = "$($Script:PSSlack.ArchiveUri)/$($response.channel)/p$($response.ts -replace '\.')"
-                    $response | Add-Member -MemberType NoteProperty -Name link -Value $link
                     $response
                 }
                 else


### PR DESCRIPTION
#125: When using `Find-SlackMessage` with the `Raw` switch, the `link` property is added twice and throws an exception. 